### PR TITLE
improve install v2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Define the GitHub repository and the name of the binary.
 GITHUB_REPO="sfcompute/cli"
 BINARY_NAME="sf"
 
 # Check the operating system
-OS="$(uname -ms)"
+OS="$(uname -s)"
+ARCH="$(uname -m)"
 
-# If the operating system is Linux, set the target directory to '/usr/local/bin'
-# If the operating system is Darwin (macOS), set the target directory to '${HOME}/.local/bin'
-if [[ "$OS" == "Linux"* ]]; then
-  TARGET_DIR="/usr/local/bin"
-elif [[ "$OS" == "Darwin"* ]]; then
-  TARGET_DIR="${HOME}/.local/bin"
-else
-  echo "Unsupported operating system: $OS"
-  exit 1
-fi
+TARGET_DIR_UNEXPANDED="\${HOME}/.local/bin"
+TARGET_DIR="${HOME}/.local/bin"
 
 # Function to check if a command exists
 command_exists() {
@@ -48,21 +41,31 @@ mkdir -p "${TARGET_DIR}"
 # Define the target file path for the 'sf' CLI binary.
 TARGET_FILE="${TARGET_DIR}/${BINARY_NAME}"
 
-if [[ "$OS" == "Linux"* ]]; then
-  if [[ "$OS" == 'Linux aarch64' ]]; then
-    target='bun-linux-arm64'
-  else 
-    target='bun-linux-x64'
-  fi  
-elif [[ "$OS" == "Darwin"* ]]; then
+if [ "$OS" = "Linux" ]; then
+  case "${ARCH}" in
+    x86_64)
+      target='bun-linux-x64'
+      ;;
+    aarch64)
+      target='bun-linux-arm64'
+      ;;
+    *)
+      echo "Unsupported Linux architecture: ${ARCH}" >&2
+      exit 1
+      ;;
+  esac
+elif [ "$OS" = "Darwin" ]; then
   sys="$(sysctl -n machdep.cpu.brand_string)"
-  if [[ $sys == *"M1"* || $sys == *"M2"* || $sys == *"M3"* ]]; then
+  case "$sys" in
+  *M1*|*M2*|*M3*)
     echo "Installing for Apple Silicon"
     target='bun-darwin-arm64'
-  else
+    ;;
+  *)
     echo "Installing for Intel Mac"
     target='bun-darwin-x64'
-  fi  
+    ;;
+  esac
 fi
 
 # Set up temporary directory for download and extraction
@@ -73,7 +76,7 @@ GITHUB=${GITHUB-"https://github.com"}
 github_repo="$GITHUB/$GITHUB_REPO"
 
 # Check if a version is provided as an argument
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
     SF_BINARY_URL=$github_repo/releases/latest/download/sf-$target.zip
 else
     VERSION=$1
@@ -98,7 +101,7 @@ unzip -o "${TMPDIR}/${BINARY_NAME}.zip" -d "${TMPDIR}/dist" ||
     { echo "Failed to extract sf"; exit 1; }
 
 # Move the binary to the target directory.
-mv "${TMPDIR}/dist/sf-$target" "${TARGET_DIR}/${BINARY_NAME}"
+mv "${TMPDIR}/dist/sf-$target" "${TARGET_FILE}"
 
 # Make the downloaded binary executable.
 chmod +x "${TARGET_FILE}"
@@ -112,20 +115,34 @@ if [ -f "${TARGET_FILE}" ]; then
     echo "The binary is located at '${TARGET_FILE}'."
 
     # Provide instructions for adding the target directory to the PATH.
-    echo -e "\033[0;32m"
-    echo -e "To use the '${BINARY_NAME}' command, add '${TARGET_DIR}' to your PATH."
-    echo -e "You can do this by running one of the following commands, depending on your shell:"
-    echo -e "\033[0m"
-    echo -e "\033[0;32mFor bash:"
-    echo -e "\033[1m  echo 'export PATH=\"${TARGET_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc\033[0m"
-    echo -e "\033[0;32m"
-    echo -e "\033[0;32mFor zsh:"
-    echo -e "\033[1m  echo 'export PATH=\"${TARGET_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc\033[0m"
-    echo -e "\033[0;32m"
-    echo -e "After running the appropriate command, you can use '${BINARY_NAME}'.\033[0m"
-    echo -e "\033[0;32m"
-    echo -e "To get started, run: 'sf login'\033[0m"
-    echo -e "\033[0;32m"
+    printf "\033[0;32m\\n"
+    printf "To use the '%s' command, add '%s' to your PATH.\\n" "${BINARY_NAME}" "${TARGET_DIR_UNEXPANDED}"
+    printf "You can do this by running one of the following commands, depending on your shell\\n"
+    printf "\033[0m\\n"
+    printf "\033[0;32mFor sh:\\n"
+    printf "\033[1m  echo 'export PATH=\"%s:\$PATH\"' >> ~/.profile && source ~/.profile\033[0m\\n" "${TARGET_DIR_UNEXPANDED}"
+    printf "\033[0;32m\\n"
+    # For bash the "proper" answer is to only modify the .profile and then as
+    # the login shell, or the desktop environment (such as the X session, or
+    # Wayland session) is supposed to load the .profile, but as many desktop
+    # environments such as xfce4 don't do this properly (and it sounds as though
+    # almost no Wayland environments handle it properly) unless the user edits
+    # their .xsessionrc the practical solution (that other installers such as
+    # rustup also use) is to set both .profile, and .bashrc.
+    #
+    # One could probably only edit .bashrc if they wanted as most distributions
+    # have ~/.profile (or ~/.bash_profile) also load .bashrc if the shell is
+    # bash.
+    printf "\033[0;32mFor bash:\\n"
+    printf "\033[1m  echo 'export PATH=\"%s:\$PATH\"' >> ~/.profile && echo 'export PATH=\"%s:\$PATH\"' >> ~/.bashrc && source ~/.profile\033[0m\\n" "${TARGET_DIR_UNEXPANDED}" "${TARGET_DIR_UNEXPANDED}"
+    printf "\033[0;32m\\n"
+    printf "\033[0;32mFor zsh:\\n"
+    printf "\033[1m  echo 'export PATH=\"%s:\$PATH\"' >> ~/.zshrc && source ~/.zshrc\033[0m\\n" "${TARGET_DIR_UNEXPANDED}"
+    printf "\033[0;32m\\n"
+    printf "After running the appropriate command, you can use '%s'.\033[0m\\n" "${BINARY_NAME}"
+    printf "\033[0;32m\\n"
+    printf "To get started, run: 'sf login'\033[0m\\n"
+    printf "\033[0;32m\\n"
 
 else
     echo "Installation failed. '${BINARY_NAME}' CLI could not be installed."


### PR DESCRIPTION
Same as v1 but without the `mv` to `mv -T` change. I guess that `shellcheck` didn't catch that issue. I tested it this time on an AWS macOS machine and it seemed to work.