### PR TITLE
Sort open orders by start time ASC order

### DIFF
--- a/src/lib/orders/index.tsx
+++ b/src/lib/orders/index.tsx
@@ -158,6 +158,9 @@ export function registerOrders(program: Command) {
 
         limit: options.limit,
         offset: options.offset,
+
+        sort_by: "start_time",
+        sort_direction: "ASC",
       });
 
       // Sort orders by start time ascending (present to future)
@@ -223,6 +226,9 @@ export async function getOrders(props: {
 
   limit?: number;
   offset?: number;
+
+  sort_by?: "created_at" | "start_time";
+  sort_direction?: "ASC" | "DESC";
 }) {
   const loggedIn = await isLoggedIn();
   if (!loggedIn) {


### PR DESCRIPTION
Users want to see orders that are closest to them in time which is `start_time`. The current sort order is based on `created_at` which is when the order was created. Users don't care about that.