### PR TITLE
fix: [ENG-1319] allow user to set explicit `end` time, round up `end` and `duration` to the nearest hour

### DIFF
--- a/.cursor/rules/cli.mdc
+++ b/.cursor/rules/cli.mdc
@@ -1,6 +1,6 @@
 ---
 description: Describes the CLI project
-globs: 
+globs: *.(ts|tsx)
 ---
 - This is a CLI program written in Deno using the `commander` library and `@commander-js/extra-typings`.
 

--- a/.cursor/rules/cli.mdc
+++ b/.cursor/rules/cli.mdc
@@ -1,0 +1,8 @@
+---
+description: Describes the CLI project
+globs: 
+---
+- This is a CLI program written in Deno using the `commander` library and `@commander-js/extra-typings`.
+
+- When using node globals like `console.log`, `setTimeout`, `process`, etc, import them from the corresponding explicit `node:console`, `node:timers`, and `node:process`, etc.
+- Where possible, use the `openapi-typescript`/`openapi-fetch` client instead of writing raw fetch calls.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       - run: deno install
       - run: deno fmt --check
       - run: deno lint
-      - run: deno check ./src/index.ts
+      - run: deno check --config deno.json ./src/index.ts

--- a/deno.json
+++ b/deno.json
@@ -10,5 +10,8 @@
   },
   "fmt": {
     "exclude": ["src/schema.ts"]
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns"]
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,6 @@
     "exclude": ["src/schema.ts"]
   },
   "compilerOptions": {
-    "lib": ["deno.ns"]
+    "lib": ["deno.ns", "deno.fetch", "deno.web"]
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -198,19 +198,19 @@
     "@types/mute-stream@0.0.4": {
       "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
       "dependencies": [
-        "@types/node@22.12.0"
-      ]
-    },
-    "@types/node@22.12.0": {
-      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
-      "dependencies": [
-        "undici-types"
+        "@types/node@22.5.4"
       ]
     },
     "@types/node@22.13.1": {
       "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dependencies": [
-        "undici-types"
+        "undici-types@6.20.0"
+      ]
+    },
+    "@types/node@22.5.4": {
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "dependencies": [
+        "undici-types@6.19.8"
       ]
     },
     "@types/prop-types@15.7.14": {
@@ -991,6 +991,9 @@
     "type-fest@4.34.1": {
       "integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g=="
     },
+    "undici-types@6.19.8": {
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
     "undici-types@6.20.0": {
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
@@ -1054,11 +1057,6 @@
     "yoga-wasm-web@0.3.3": {
       "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="
     }
-  },
-  "remote": {
-    "https://deno.land/std@0.112.0/fmt/colors.ts": "8368ddf2d48dfe413ffd04cdbb7ae6a1009cf0dccc9c7ff1d76259d9c61a0621",
-    "https://deno.land/std@0.112.0/testing/_diff.ts": "ccd6c3af6e44c74bf1591acb1361995f5f50df64323a6e7fb3f16c8ea792c940",
-    "https://deno.land/std@0.112.0/testing/asserts.ts": "cb82284da34f9e863250efacb985886336a9bbdcd2cf81cc9311a32aff53da35"
   },
   "workspace": {
     "dependencies": [

--- a/src/checkVersion.ts
+++ b/src/checkVersion.ts
@@ -1,6 +1,7 @@
 import boxen from "boxen";
 import chalk from "chalk";
 import { execSync } from "node:child_process";
+import * as console from "node:console";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -69,12 +70,13 @@ async function checkProductionCLIVersion() {
   // Fetch from network
   try {
     const response = await fetch(
-      "https://raw.githubusercontent.com/sfcompute/cli/refs/heads/main/package.json"
+      "https://raw.githubusercontent.com/sfcompute/cli/refs/heads/main/package.json",
     );
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    const data = await response.json();
+    // deno-lint-ignore no-explicit-any -- Deno has narrower types for fetch responses, but we know this code works atm.
+    const data = await response.json() as any;
     await writeCache(data.version);
     return data.version;
   } catch (error) {
@@ -103,7 +105,7 @@ export async function checkVersion() {
 
   if (isPatchUpdate) {
     console.log(
-      chalk.cyan(`Automatically upgrading ${version} → ${latestVersion}`)
+      chalk.cyan(`Automatically upgrading ${version} → ${latestVersion}`),
     );
     try {
       execSync("sf upgrade", { stdio: "inherit" });
@@ -131,7 +133,7 @@ Run 'sf upgrade' to update to the latest version
         padding: 1,
         borderColor: "yellow",
         borderStyle: "round",
-      })
+      }),
     );
   }
 }

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,4 +1,5 @@
 import { unlinkSync } from "node:fs";
+import * as console from "node:console";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import * as console from "node:console";
 import { getCommandBase } from "./command.ts";
 import { clearAuthFromConfig } from "./config.ts";
 

--- a/src/helpers/feature-flags.ts
+++ b/src/helpers/feature-flags.ts
@@ -42,7 +42,7 @@ export async function loadFeatureFlags(): Promise<FeatureFlagCache> {
 
 export async function getCachedFeatureFlag(
   feature: string,
-  accountId: string
+  accountId: string,
 ): Promise<CachedFeatureFlag | null> {
   const cache = await loadFeatureFlags();
   const key = `${accountId}:${feature}`;
@@ -65,7 +65,7 @@ export async function getCachedFeatureFlag(
 export async function cacheFeatureFlag(
   feature: string,
   accountId: string,
-  value: boolean
+  value: boolean,
 ): Promise<void> {
   const cache = await loadFeatureFlags();
   const key = `${accountId}:${feature}`;

--- a/src/helpers/units.ts
+++ b/src/helpers/units.ts
@@ -101,13 +101,16 @@ export function centsToDollars(cents: Cents): number {
 export function dollarsToCents(dollars: number): Cents {
   return Math.ceil(dollars * 100);
 }
-
-export function parseStartDate(startDate?: string): Date {
-  if (!startDate) return new Date();
-
+export function parseStartDateOrNow(startDate?: string): Date | "NOW" {
+  if (!startDate) return "NOW";
   const nowRe = /\b(?:"|')?[nN][oO][wW](?:"|')?\b/;
-  if (nowRe.test(startDate)) return new Date();
-
+  if (nowRe.test(startDate)) return "NOW";
   const chronoDate = chrono.parseDate(startDate);
-  return chronoDate ?? new Date();
+  return chronoDate ?? "NOW";
+}
+
+export function parseStartDate(startDate?: string | Date): Date {
+  if (startDate instanceof Date) return startDate;
+  const result = parseStartDateOrNow(startDate);
+  return result === "NOW" ? new Date() : result;
 }

--- a/src/helpers/units.ts
+++ b/src/helpers/units.ts
@@ -102,16 +102,12 @@ export function dollarsToCents(dollars: number): Cents {
   return Math.ceil(dollars * 100);
 }
 
-export function parseStartDate(startDate: string): Date | "NOW" | null {
+export function parseStartDate(startDate?: string): Date {
+  if (!startDate) return new Date();
+
   const nowRe = /\b(?:"|')?[nN][oO][wW](?:"|')?\b/;
-  if (nowRe.test(startDate)) {
-    return "NOW";
-  }
+  if (nowRe.test(startDate)) return new Date();
 
   const chronoDate = chrono.parseDate(startDate);
-  if (!chronoDate) {
-    return null;
-  }
-
-  return chronoDate;
+  return chronoDate ?? new Date();
 }

--- a/src/helpers/urls.ts
+++ b/src/helpers/urls.ts
@@ -22,7 +22,6 @@ const apiPaths: Record<string, Path<IdParams | never>> = {
   me: "/v0/me",
   ping: "/v0/ping",
 
-  orders_create: "/v0/orders",
   orders_list: "/v0/orders",
   orders_get: ({ id }: IdParams): string => `/v0/orders/${id}`,
   orders_cancel: ({ id }: IdParams): string => `/v0/orders/${id}`,

--- a/src/helpers/waitingForOrder.ts
+++ b/src/helpers/waitingForOrder.ts
@@ -1,4 +1,5 @@
 import ora from "ora";
+import { setTimeout } from "node:timers";
 import { logAndQuit } from "./errors.ts";
 import { getOrder } from "./fetchers.ts";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,8 @@ const main = async () => {
         },
       });
 
-      const data = await response.json();
+      // deno-lint-ignore no-explicit-any -- Deno has narrower types for fetch responses, but we know this code works atm.
+      const data = await response.json() as any;
       if (data.id) {
         exchangeAccountId = data.id;
         saveConfig({ ...config, account_id: data.id });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from "@commander-js/extra-typings";
+import * as console from "node:console";
 import os from "node:os";
 import process from "node:process";
 import pkg from "../package.json" with { type: "json" };

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import Table from "cli-table3";
+import * as console from "node:console";
 import type { Command } from "@commander-js/extra-typings";
 import { apiClient } from "../apiClient.ts";
 import { isLoggedIn } from "../helpers/config.ts";

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -27,7 +27,6 @@ import QuoteDisplay from "../Quote.tsx";
 import { Row } from "../Row.tsx";
 import { GPUS_PER_NODE } from "../constants.ts";
 import { analytics } from "../posthog.ts";
-import console from "node:console";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -192,7 +192,10 @@ function QuoteAndBuy(props: { options: SfBuyOptions }) {
         );
       } else if (end) {
         endsAt = end;
-        props.options.duration = dayjs(endsAt).diff(dayjs(coercedStart), "seconds");
+        props.options.duration = dayjs(endsAt).diff(
+          dayjs(coercedStart),
+          "seconds",
+        );
       } else {
         throw new Error("Either duration or end must be set");
       }

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -181,7 +181,9 @@ function QuoteAndBuy(props: { options: SfBuyOptions }) {
       if (duration) {
         // If duration is set, calculate end from start + duration
         const coercedStart = parseStartDate(start);
-        endsAt = roundEndDate(dayjs(coercedStart).add(duration, "seconds").toDate());
+        endsAt = roundEndDate(
+          dayjs(coercedStart).add(duration, "seconds").toDate(),
+        );
       } else if (end) {
         // If end is set, calculate duration from end - start
         endsAt = end;

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -76,7 +76,7 @@ function _registerBuy(program: Command) {
       "Colocate with existing contracts",
       (value) => value.split(","),
     )
-    .option("--quote", "Only provide a quote for the order")
+    .option("-q, --quote", "Only provide a quote for the order")
     .action(function buyOrderAction(options) {
       /*
        * Flow is:
@@ -109,13 +109,13 @@ function parseAccelerators(accelerators?: string) {
     return 1;
   }
 
-  const nodes = Number.parseInt(accelerators) / GPUS_PER_NODE;
-  if (!Number.isInteger(nodes)) {
+  const parsedValue = Number.parseInt(accelerators);
+  if (!Number.isInteger(parsedValue / GPUS_PER_NODE)) {
     return logAndQuit(
       `You can only buy whole nodes, or 8 GPUs at a time. Got: ${accelerators}`,
     );
   }
-  return nodes;
+  return parsedValue;
 }
 
 function parseDuration(duration?: string) {
@@ -342,8 +342,8 @@ function BuyOrder(props: BuyOrderProps) {
 
   async function submitOrder() {
     const { startAt, endsAt } = props;
-    const realDurationInHours = dayjs(endsAt).diff(dayjs(startAt)) / 1000 /
-      3600;
+    const realDurationInHours =
+      dayjs(endsAt).diff(dayjs(parseStartDate(startAt))) / 1000 / 3600;
 
     setIsLoading(true);
     const order = await placeBuyOrder({
@@ -589,8 +589,8 @@ async function getQuoteFromParsedSfBuyOptions(options: SfBuyOptions) {
     : roundStartDate(parseStartDate(options.start));
   const durationSeconds = options.duration
     ? options.duration
-    : dayjs(options.end).diff(dayjs(startsAt), "seconds");
-  const quantity = options.accelerators;
+    : dayjs(options.end).diff(dayjs(parseStartDate(startsAt)), "seconds");
+  const quantity = options.accelerators / GPUS_PER_NODE;
 
   const minDurationSeconds = Math.max(
     1,

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -1,5 +1,6 @@
 import { parseDate } from "chrono-node";
 import type { Command } from "@commander-js/extra-typings";
+import { clearInterval, setInterval, setTimeout } from "node:timers";
 import { Box, render, Text, useApp } from "ink";
 import Spinner from "ink-spinner";
 import ms from "ms";

--- a/src/lib/clusters/clusters.tsx
+++ b/src/lib/clusters/clusters.tsx
@@ -1,4 +1,6 @@
 import type { Command } from "@commander-js/extra-typings";
+import * as console from "node:console";
+import { clearInterval, setInterval, setTimeout } from "node:timers";
 import { Box, render, Text, useApp } from "ink";
 import Spinner from "ink-spinner";
 import React, { useEffect, useState } from "react";

--- a/src/lib/contracts/index.tsx
+++ b/src/lib/contracts/index.tsx
@@ -1,4 +1,5 @@
 import { Command } from "@commander-js/extra-typings";
+import * as console from "node:console";
 import { render } from "ink";
 import React from "react";
 import { apiClient } from "../../apiClient.ts";

--- a/src/lib/dev.ts
+++ b/src/lib/dev.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import * as console from "node:console";
 import { confirm } from "@inquirer/prompts";
 import chalk from "chalk";
 import type { Command } from "@commander-js/extra-typings";

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -34,7 +34,7 @@ export function registerLogin(program: Command) {
       clearScreen();
       console.log(`\n\n  Click here to login:\n  ${url}\n\n`);
       console.log(
-        `  Do these numbers match your browser window?\n  ${validation}\n\n`
+        `  Do these numbers match your browser window?\n  ${validation}\n\n`,
       );
 
       const checkSession = async () => {
@@ -75,7 +75,7 @@ async function createSession({ validation }: { validation: string }) {
           "Content-Type": "application/json",
         },
         maxRedirects: 5,
-      }
+      },
     );
 
     return response.data as {

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -1,6 +1,8 @@
 import type { Command } from "@commander-js/extra-typings";
+import * as console from "node:console";
 import { exec } from "node:child_process";
 import process from "node:process";
+import { setTimeout } from "node:timers";
 import ora from "ora";
 import { saveConfig } from "../helpers/config.ts";
 import { clearScreen } from "../helpers/prompt.ts";

--- a/src/lib/me.ts
+++ b/src/lib/me.ts
@@ -1,4 +1,5 @@
 import type { Command } from "@commander-js/extra-typings";
+import * as console from "node:console";
 import { isLoggedIn, loadConfig } from "../helpers/config.ts";
 import {
   logAndQuit,

--- a/src/lib/me.ts
+++ b/src/lib/me.ts
@@ -41,5 +41,6 @@ export async function getLoggedInAccountId() {
 
   const data = await response.json();
 
+  // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
   return data.id;
 }

--- a/src/lib/orders/index.tsx
+++ b/src/lib/orders/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../helpers/errors.ts";
 import { fetchAndHandleErrors } from "../../helpers/fetch.ts";
 import { getApiUrl } from "../../helpers/urls.ts";
-import { parseStartAsDate } from "../buy/index.tsx";
+import { parseStartDate } from "../../helpers/units.ts";
 import { OrderDisplay } from "./OrderDisplay.tsx";
 import type { HydratedOrder, ListResponseBody } from "./types.ts";
 import * as console from "node:console";
@@ -214,8 +214,8 @@ export function registerOrders(program: Command) {
 
       // Sort orders by start time ascending (present to future)
       const sortedOrders = [...orders].sort((a, b) => {
-        const aStart = parseStartAsDate(a.start_at);
-        const bStart = parseStartAsDate(b.start_at);
+        const aStart = parseStartDate(a.start_at);
+        const bStart = parseStartDate(b.start_at);
         return aStart.getTime() - bStart.getTime();
       });
 

--- a/src/lib/orders/index.tsx
+++ b/src/lib/orders/index.tsx
@@ -330,6 +330,7 @@ export async function submitOrderCancellationByIdAction(
     }
 
     const error = await response.json();
+    // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
     switch (error.code) {
       case "order.not_found":
         return logAndQuit(`Order ${orderId} not found`);
@@ -342,6 +343,7 @@ export async function submitOrderCancellationByIdAction(
   }
 
   const resp = await response.json();
+  // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
   const cancellationSubmitted = resp.object === "pending";
   if (!cancellationSubmitted) {
     return logAndQuit(`Failed to cancel order ${orderId}`);

--- a/src/lib/orders/index.tsx
+++ b/src/lib/orders/index.tsx
@@ -16,6 +16,7 @@ import { getApiUrl } from "../../helpers/urls.ts";
 import { parseStartAsDate } from "../buy/index.tsx";
 import { OrderDisplay } from "./OrderDisplay.tsx";
 import type { HydratedOrder, ListResponseBody } from "./types.ts";
+import * as console from "node:console";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -44,8 +44,8 @@ const trackEvent = ({
           Authorization: `Bearer ${config.auth_token}`,
         },
       });
-
-      const data = await response.json();
+      // deno-lint-ignore no-explicit-any -- Deno has narrower types for fetch responses, but we know this code works atm.
+      const data = await response.json() as any;
       if (data.id) {
         exchangeAccountId = data.id;
         saveConfig({ ...config, account_id: data.id });

--- a/src/lib/sell/index.tsx
+++ b/src/lib/sell/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../helpers/errors.ts";
 import parseDurationFromLibrary from "parse-duration";
 import { Box, render, useApp } from "ink";
-import { parseDate } from "chrono-node";
+import { parseStartDate } from "../../helpers/units.ts";
 import { GPUS_PER_NODE } from "../constants.ts";
 import { useCallback, useEffect, useState } from "react";
 import { Text } from "ink";
@@ -79,7 +79,7 @@ export function registerSell(program: Command) {
           return logAndQuit(`Invalid duration: ${options.duration}`);
         }
 
-        const startDate = parseStartAsDate(options.start);
+        const startDate = parseStartDate(options.start);
         if (!startDate) {
           return logAndQuit(`Invalid start date: ${options.start}`);
         }
@@ -109,32 +109,6 @@ export function registerSell(program: Command) {
         render(<SellOrder {...orderDetails} />);
       },
     );
-}
-
-function parseStart(start?: string) {
-  if (!start) {
-    return "NOW";
-  }
-
-  if (start === "NOW" || start === "now") {
-    return "NOW";
-  }
-
-  const parsed = parseDate(start);
-  if (!parsed) {
-    return logAndQuit(`Invalid start date: ${start}`);
-  }
-
-  return parsed;
-}
-
-function parseStartAsDate(start?: string) {
-  const date = parseStart(start);
-  if (date === "NOW") {
-    return new Date();
-  }
-
-  return date;
 }
 
 function parseAccelerators(accelerators?: string) {

--- a/src/lib/sell/index.tsx
+++ b/src/lib/sell/index.tsx
@@ -1,4 +1,5 @@
 import type { Command } from "@commander-js/extra-typings";
+import { clearInterval, setInterval } from "node:timers";
 import dayjs from "npm:dayjs@1.11.13";
 import duration from "npm:dayjs@1.11.13/plugin/duration.js";
 import relativeTime from "npm:dayjs@1.11.13/plugin/relativeTime.js";
@@ -101,7 +102,7 @@ export function registerSell(program: Command) {
           size: size,
           startAt: startDate,
           endsAt: endDate,
-          flags: options.flags,
+          flags: options.flags as SellOrderFlags, // TODO: explicitly parse and validate this
           autoConfirm: options.yes || false,
         };
 

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -138,6 +138,7 @@ async function createTokenAction() {
   // display token to user
   const data = await response.json();
   loadingSpinner.succeed(chalk.gray("Access token created 🎉"));
+  // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
   console.log(chalk.green(data.token) + "\n");
 
   // tell them they will set this in the Authorization header
@@ -161,9 +162,10 @@ async function createTokenAction() {
   const pingUrl = await getApiUrl("ping");
   console.log(`${chalk.gray("Here is a sample curl to get your started:")}`);
   console.log(
-    chalk.white(`curl --request GET \\
-  --url ${pingUrl} \\
-  --header 'Authorization: Bearer ${data.token}'`),
+    chalk.white(
+      // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
+      `curl --request GET --url ${pingUrl} --header 'Authorization: Bearer ${data.token}'`,
+    ),
   );
   console.log("\n");
 
@@ -215,6 +217,7 @@ async function listTokensAction() {
 
   // show account tokens
   const responseBody = await response.json();
+  // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
   const tokens = responseBody.data as Array<TokenObject>;
 
   // show empty table if no tokens
@@ -323,6 +326,7 @@ async function deleteTokenById(id: string) {
     }
 
     const error = await response.json();
+    // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
     if (error.code === "token.not_found") {
       loadingSpinner.fail("Token not found");
       process.exit(1);

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import * as console from "node:console";
 import { confirm, input, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import Table from "cli-table3";

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -1,5 +1,6 @@
 import type { Command } from "@commander-js/extra-typings";
 import process from "node:process";
+import * as console from "node:console";
 import ora from "ora";
 
 /**

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -17,6 +17,7 @@ const getIsOnLatestVersion = async (currentVersion: string | undefined) => {
 
   if (latestVersionResponse.ok) {
     const latestVersionData = await latestVersionResponse.json();
+    // @ts-ignore: Deno has narrower types for fetch responses, but we know this code works atm.
     const latestVersion = latestVersionData.tag_name;
 
     return latestVersion === currentVersion;

--- a/src/lib/vm.ts
+++ b/src/lib/vm.ts
@@ -1,5 +1,6 @@
 import type { Command } from "@commander-js/extra-typings";
 import process from "node:process";
+import * as console from "node:console";
 import { isFeatureEnabled } from "./posthog.ts";
 
 export async function registerVM(program: Command) {

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -1,4 +1,4 @@
-import { Command, Argument } from "@commander-js/extra-typings";
+import { Argument, Command } from "@commander-js/extra-typings";
 import process from "node:process";
 import * as console from "node:console";
 
@@ -180,7 +180,11 @@ program
   .description(
     "A github release tool for the project. Valid types are: major, minor, patch, prerelease",
   )
-  .addArgument(new Argument("type").choices(["major", "minor", "patch", "prerelease"] as const))
+  .addArgument(
+    new Argument("type").choices(
+      ["major", "minor", "patch", "prerelease"] as const,
+    ),
+  )
   .action(async (type) => {
     try {
       const ghCheckResult = await new Deno.Command("which", {

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -1,5 +1,6 @@
-import { Command } from "@commander-js/extra-typings";
+import { Command, Argument } from "@commander-js/extra-typings";
 import process from "node:process";
+import * as console from "node:console";
 
 const program = new Command();
 
@@ -179,26 +180,9 @@ program
   .description(
     "A github release tool for the project. Valid types are: major, minor, patch, prerelease",
   )
-  .arguments("[type]")
+  .addArgument(new Argument("type").choices(["major", "minor", "patch", "prerelease"] as const))
   .action(async (type) => {
     try {
-      if (!type || type === "") {
-        program.help();
-        process.exit(1);
-      }
-
-      const validTypes = ["major", "minor", "patch", "prerelease"];
-      if (!validTypes.includes(type)) {
-        console.error(
-          `Invalid release type: ${type}. Valid types are: ${
-            validTypes.join(
-              ", ",
-            )
-          }`,
-        );
-        process.exit(1);
-      }
-
       const ghCheckResult = await new Deno.Command("which", {
         args: ["gh"],
       }).output();

--- a/src/types/deno.d.ts
+++ b/src/types/deno.d.ts
@@ -1,8 +1,0 @@
-declare namespace Deno {
-  function writeTextFile(path: string, data: string): Promise<void>;
-  function readTextFile(path: string): Promise<string>;
-  function mkdir(
-    path: string,
-    options?: { recursive?: boolean },
-  ): Promise<void>;
-}


### PR DESCRIPTION
Fixes the error where a user sets an explicit duration for a buy order, and it doesn't end on an hour boundary. Rounds the end time/duration up to the next hour boundary.