### PR TITLE
Fix invalid extraction directory error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,6 +113,7 @@ if ! unzip -t "${TMPDIR}/${BINARY_NAME}.zip" >/dev/null 2>&1; then
 fi
 
 # Extract the zip file in the temporary directory.
+mkdir "${TMPDIR}/dist"
 echo "unzip -o \"${TMPDIR}/${BINARY_NAME}.zip\" -d \"${TMPDIR}/dist\""
 unzip -o "${TMPDIR}/${BINARY_NAME}.zip" -d "${TMPDIR}/dist" || { echo "Failed to extract sf"; exit 1; }
 


### PR DESCRIPTION
Fixes #82 by adding an `mkdir` before trying to extract the downloaded zip file.