### PR TITLE
Add copywriting and design guidelines for improved user communication

### DIFF
--- a/.cursor/rules/copywriting.mdc
+++ b/.cursor/rules/copywriting.mdc
@@ -1,0 +1,158 @@
+---
+description: Rules for writing copy/text
+globs: 
+alwaysApply: true
+---
+## Keep It Clear and Concise
+- Avoid unnecessary words. Get straight to the point.
+- **Example:** Instead of *"Your cluster will start as soon as possible,"* say **"Launch instantly."**
+
+## No Fluff or Marketing Speak
+- Avoid phrases that sound overly promotional or vague.
+- **Example:** Instead of *"Unlock the power of GPUs,"* say **"Deploy an H100 GPU cluster."**
+
+## Action-Oriented Language
+- Focus on what the user needs to do, not generic descriptions.
+- **Example:** Instead of *"You will need the SF Compute CLI and kubectl,"* say **"Install [SF Compute CLI](mdc:#) and [kubectl](mdc:#) to access your cluster."**
+
+## Consistent Formatting & Terminology
+- Use the same terms across the app (e.g., **"Cluster Duration"** instead of sometimes saying **"Run Time"**).
+- Use numerals for numbers (**"8 GPUs"**, not **"eight GPUs"**).
+
+## Be Precise About Technical Details
+- If something requires installation, say so.
+- If a feature is unavailable, specify when it’s coming or provide an alternative.
+
+## No Redundant Information
+- Don't repeat what the user already knows.
+- **Example:** Instead of *"You are placing an order for a K8s cluster,"* just tell them what they need to do next.
+
+## Make Buttons and Actions Clear
+- **"Place Order"** → **"Confirm Order"** (if payment isn’t immediate).
+- **"Make Changes"** → **"Edit Order"** (for clarity).
+
+## Use a Neutral, Professional Tone
+- Avoid overly casual language unless intentional.
+- **Example:** Instead of *"Almost there! Just install this tool,"* say **"Install [SF Compute CLI](mdc:#) and [kubectl](mdc:#) to access your cluster."**
+
+## Anticipate User Questions
+- If something might be unclear, preemptively address it.
+- **Example:** If persistent storage isn’t available yet, say **"Persistent storage (Coming soon). Contact us for alternatives."**
+
+## Ensure UI Copy Feels Integrated
+- Help text shouldn’t feel disconnected from the main UI.
+- **Example:** If help text is too far from the relevant section, move it closer or embed it as a bullet point.
+## Avoid Ambiguous Timeframes
+- Be **precise** about when something will happen.  
+- **Example:** Instead of *"Your cluster will start shortly,"* say **"Your cluster will be ready in under 60 seconds."**  
+
+## Use User-Centered Language
+- Focus on what **the user** needs, not what the system does.  
+- **Example:** Instead of *"The system will allocate GPUs,"* say **"Your cluster will have dedicated GPUs."**  
+
+## Don't Assume Prior Knowledge
+- If using technical terms, **briefly explain or link to docs**.  
+- **Example:** Instead of *"Use InfiniBand networking,"* say **"Use InfiniBand networking (high-speed data transfer between nodes)."**  
+
+## Default to Positive Language
+- Frame messages in an **encouraging, problem-solving way**, even for errors.  
+- **Example:** Instead of *"Your order failed,"* say **"Something went wrong—try again or contact support."**  
+
+## Minimize Distractions in Critical Actions
+- During checkout or confirmations, **keep the user focused** by avoiding extra links or unnecessary text.  
+- **Example:** Instead of:  
+  > "You're about to place an order for a cluster. Did you know we also offer persistent storage? Contact us for more info."  
+  Use:  
+  > "Review your order details, then confirm your cluster setup."  
+
+## Write Error Messages That Guide Users
+- Don’t just state **what went wrong—tell them how to fix it**.  
+- **Example:** Instead of *"Invalid API key,"* say **"Your API key is incorrect or expired. Generate a new key in your account settings."**  
+
+## Keep Confirmation Messages Clear & Reassuring
+- After an action, let users know **what happens next**.  
+- **Example:** Instead of *"Your order was placed,"* say **"Your cluster is being deployed. You’ll receive access details shortly."**  
+
+## Keep Form Labels and Inputs Simple
+- Labels should be **short and clear**.  
+- Placeholder text should **not repeat labels**.  
+- **Example:**  
+  - Bad *"Please enter your email address below:"*  
+  - Good **Label:** "Email" → **Input Placeholder:** "you@example.com"  
+
+## Ensure All Call-to-Action (CTA) Buttons Are Specific
+- Every button should **describe the action it triggers**.  
+- **Example:**  
+  - Bad "Submit"  
+  - Good "Deploy Cluster"  
+
+  ## Keep It Short, but Not Cryptic
+- Use the **fewest words possible** without losing clarity.
+- **Example:** Instead of *"Your cluster is now being provisioned and will be available shortly,"* say **"Provisioning your cluster…"**  
+- Avoid unnecessary explanations—**the UI should guide users, not overwhelm them**.
+
+## Prioritize Clarity Over Cleverness
+- Avoid jargon unless your audience **already understands it**.  
+- **Example:** Instead of *"GPU nodes are booting up,"* say **"Your GPUs are starting up."**
+- Don’t use technical terms **just to sound impressive**—only when they’re necessary.
+
+## Show, Don’t Tell
+- If an action **is already obvious from the UI**, **don’t repeat it**.  
+- **Example:** If there’s a "Deploy" button, **no need to add text saying "Click deploy to start your app."**
+- Let **labels, buttons, and structure** guide the user instead of over-explaining.
+
+## Use Sentence Case Everywhere
+- Except for Buttons and Links.
+- **Example:**  
+  - Bad *"Confirm Your Order"*  
+  - Good **"Confirm your order"**
+
+## Error Messages Should Be Helpful, Not Alarming
+- **Explain what happened and how to fix it.**
+- **Example:** Instead of *"Error 503: Something went wrong,"* say **"Server is temporarily unavailable. Try again in a few minutes."**
+- Keep it **calm and constructive**—users shouldn’t feel like they broke something.
+
+## CTA Buttons Should Be Actionable
+- Buttons should **describe the action** clearly.
+- **Example:**  
+  - Bad *"Submit"*  
+  - Good **"Deploy Cluster"**  
+  - Good **"Generate API Key"**  
+- Avoid vague labels like **"OK"** or **"Done"** if they can be more specific.
+
+## Use Progressive Disclosure for Complex Information
+- **Don’t overload users with details upfront.**
+- Show advanced settings **only when needed**.
+- **Example:** Instead of displaying **all API settings** immediately, add a **"Show advanced settings"** toggle.
+
+## Default to a Professional, Neutral Tone
+- Avoid sounding too **robotic** or too **casual**.
+- **Example:** Instead of *"Oops! Something went wrong 😢,"* say **"We couldn't complete your request. Try again in a moment."**
+- Keep personality **subtle**—Vercel and Linear add warmth through **clean design**, not excessive humor.
+
+## Confirm Actions with Context
+- **When users take an important action, confirm it.**
+- **Example:** After deploying, instead of just closing the modal, show:  
+  > **"Your app has been deployed. View it live at [yourdomain.com](mdc:#)."**  
+- This reassures users **something actually happened**.
+
+## Avoid Passive Voice
+- Make copy **direct and active**.
+- **Example:**  
+  - Bad *"Your order has been placed."*  
+  - Good **"You placed your order."**  
+  - Bad *"Clusters are being deployed."*  
+  - Good **"Deploying your cluster…"**
+
+## Keep the UI Copy Consistent
+- If you call it **"Cluster Size"** in one place, **don’t call it "GPU Count" elsewhere**.
+- Consistency builds **trust and usability**.
+
+## Assume the User Knows What They’re Doing
+- Don’t over-explain concepts **developers already understand**.
+- **Example:** Instead of *"A Kubernetes cluster is a set of machines that…"*, just **link to docs**.
+- Keep in-product copy **focused on action, not education**.
+
+## If It’s Not Necessary, Remove It
+- Every extra word **adds friction**.  
+- **Example:** Instead of *"Your cluster setup is now complete and you can start using it,"* say **"Your cluster is ready."**

--- a/.cursor/rules/guidelines.mdc
+++ b/.cursor/rules/guidelines.mdc
@@ -1,0 +1,188 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+## 1. General Design Principles
+
+1. **Human-First**  
+   - If humans primarily use your CLI, design it for **humans first**.  
+   - Keep commands, flags, and feedback understandable at a glance.
+
+2. **Composability**  
+   - Adhere to UNIX conventions (stdin, stdout, stderr, exit codes).  
+   - Make your CLI easy to combine with other tools via piping and scripts.
+
+3. **Consistency**  
+   - Follow existing CLI conventions where possible (e.g., `-h`, `--help`).  
+   - Standardize naming, output style, and argument/flag syntax across commands.
+
+4. **Balance in Output**  
+   - Provide enough information for clarity, but avoid overwhelming the user.  
+   - Respect both human readability and machine readability (consider `--json`).
+
+5. **Discoverability**  
+   - Offer meaningful help and examples.  
+   - Suggest next steps, correct mistakes politely, and surface features without burying them.
+
+6. **Conversational Interaction**  
+   - Recognize that users run multiple related commands to achieve a goal.  
+   - Provide helpful errors, confirmations, and suggestions to guide them step by step.
+
+7. **Robustness & Empathy**  
+   - Handle unexpected input gracefully.  
+   - Always appear stable and trustworthy.  
+   - Include thoughtful error messages and gentle guidance.
+
+8. **Willingness to Break Rules Deliberately**  
+   - Adhere to known patterns, but if a rule truly harms your users, break it intentionally.  
+   - Document and justify your decisions.
+
+
+## 2. Essential CLI Behaviors
+
+1. **Argument Parsing**  
+   - Use a standard argument-parsing library (e.g., Python’s `argparse`, Rust’s `clap`).  
+   - Leverage built-in features for spelling suggestions, help text, etc.
+
+2. **Exit Codes**  
+   - Return **0** on success, **non-zero** on failure.  
+   - Map different failure modes to distinct exit codes when relevant.
+
+3. **stdout & stderr**  
+   - Send primary output to **stdout**.  
+   - Send logs, prompts, and errors to **stderr**.
+
+4. **Help & Documentation**  
+   - **Display help** with no arguments, `-h`, or `--help`.  
+   - Provide concise help with usage, a brief description, and top flags/subcommands.  
+   - Show **full help** (including all flags and commands) with `-h` or `--help`.  
+   - **Examples** should be near the top of help text, especially for common or complex tasks.  
+   - Link to more extensive docs online or in man pages.  
+   - Provide a **feedback channel** (URL or repository link).
+
+
+
+## 3. Output Guidelines
+
+1. **Human-Readable by Default**  
+   - Favor short, clear messages about what happened (especially after changes).  
+   - Use paging (e.g., `less`) only when in a TTY and the text is long.
+
+2. **Machine-Readable Options**  
+   - Provide `--json` (or similar) for structured output.  
+   - Provide `--plain` if color or special formatting might break simple text parsing.
+
+3. **Minimal but Informative**  
+   - Show output on success, but keep it brief (e.g., “Operation succeeded”).  
+   - Show progress for slow operations. Keep the user informed and reassured.  
+   - **Confirm** destructive actions with a prompt unless suppressed by `-f` or `--force`.
+
+4. **Color & Symbols**  
+   - Use color sparingly; disable it when:
+     - `NO_COLOR` is set
+     - Output is not in a TTY
+     - User passes `--no-color`  
+   - Emoji or symbols are acceptable if they clarify without distracting.
+
+5. **Errors**  
+   - Rewrite error messages in plain language with actionable suggestions.  
+   - Summarize multiple similar errors under a single explanatory header.  
+   - Provide instructions for bug reporting without overwhelming default output.
+
+
+## 4. Arguments & Flags
+
+1. **Prefer Named Flags Over Positional Arguments**  
+   - Exceptions: simple commands like `cp <source> <destination>` or multiple files for `rm file1 file2 file3`.  
+   - Always provide long and short flag names (e.g., `-h`, `--help`).
+
+2. **Common Flags**  
+   - `-h, --help`, `--json`, `-q, --quiet`, `-d, --debug`, `-f, --force`, `--version`, `-o, --output`.  
+   - Avoid using these for non-standard purposes.
+
+3. **Prompt for Missing Data**  
+   - If crucial data is not provided, prompt for it interactively (only if in a TTY).  
+   - Provide a non-interactive mode with flags or `--no-input`.
+
+4. **Confirmation for Destructive Actions**  
+   - Prompt the user to type `y`/`yes` (or a resource name) for high-risk operations.  
+   - Provide `--force` or `--confirm` for usage in scripts.
+
+5. **`-` as stdin/stdout**  
+   - When the input or output is a file, allow `-` to denote stdin or stdout.
+
+
+## 5. Subcommands
+
+1. **Use Subcommands for Complex Tools**  
+   - Group related functionalities (e.g., `git add`, `git commit`).  
+   - Keep naming, output style, and flags consistent across subcommands.
+
+2. **Noun–Verb or Verb–Noun Pattern**  
+   - Choose a consistent approach (e.g., `docker container create`).  
+   - Avoid ambiguous or similarly named commands.
+
+3. **No Hidden Magic**  
+   - Don’t allow a catch-all subcommand that guesses user intent.  
+   - Disallow arbitrary abbreviations that block future expansions.
+
+
+## 6. Interactivity & Signals
+
+1. **Interact Only if in a TTY**  
+   - If not a TTY, either fail or require explicit flags to provide necessary info.  
+   - Provide `--no-input` to disable prompts entirely.
+
+2. **Secrets**  
+   - Never take passwords or tokens via flags; use stdin or files.  
+   - Disable echo when prompting for secrets.
+
+3. **Graceful Interrupts**  
+   - Respect `Ctrl-C` (SIGINT); exit quickly or skip lengthy cleanup.  
+   - If partial cleanup is risky, clarify how to force termination.
+
+
+## 7. Configuration & Environment Variables
+
+1. **Configuration Precedence**  
+   - **Flags** → **environment variables** → **project-level config** → **user-level config** → **system-level config**.  
+   - Use flags for frequent changes, environment variables for context-based changes, and config files for stable or versioned settings.
+
+2. **XDG Base Directories**  
+   - Follow `~/.config` for user-level config where applicable.  
+   - Minimize creation of hidden dotfiles.
+
+3. **.env Usage**  
+   - Accept environment variables from `.env` for local, project-specific convenience.  
+   - For complex or shared configuration, prefer a dedicated config file under version control.
+
+4. **No Secrets in Environment Variables**  
+   - Environment variables can easily leak into logs, process states, or Docker inspect.  
+   - Accept secrets only via credential files, pipes, sockets, or secure services.
+
+
+## 8. Future-Proofing
+
+1. **Stable Interfaces**  
+   - Subcommands, flags, outputs: do not break them without a deprecation window.  
+   - Use additive changes wherever possible.
+
+2. **Deprecation Warnings**  
+   - Print a warning when users invoke soon-to-be-removed flags or subcommands.  
+   - Suggest an immediate migration path.
+
+3. **Avoid Catch-All or Automatic Behavior**  
+   - Don’t let a non-existent subcommand become a future naming conflict.  
+   - Skip arbitrary abbreviations that could block future expansions.
+
+
+## 9. Naming
+
+1. **Lowercase & Short**  
+   - Keep your executable name memorable and collision-free.  
+   - Avoid overly generic names or collisions with existing commands.
+
+2. **Easy to Type**  
+   - Minimize awkward finger movements, especially if users call it frequently.
+


### PR DESCRIPTION
This commit introduces two new markdown files: `copywriting.mdc` and `guidelines.mdc`. The `copywriting.mdc` file outlines rules for writing clear, concise, and user-centered copy, while the `guidelines.mdc` provides essential design principles and behaviors for CLI tools, focusing on human-first design, consistency, and effective error handling. These documents aim to enhance user experience and ensure clarity in communication across the application.