### PR TITLE
vms/logs: rm params.append(before|since) - it has no effect

### DIFF
--- a/src/lib/vm.ts
+++ b/src/lib/vm.ts
@@ -148,12 +148,6 @@ export async function registerVM(program: Command) {
       if (options.limit) {
         params.append("limit", options.limit);
       }
-      if (options.before) {
-        params.append("before", options.before);
-      }
-      if (options.since) {
-        params.append("since", options.since);
-      }
 
       // Function to fetch logs with given parameters
       async function fetchLogs(urlParams: URLSearchParams) {

--- a/src/lib/vm.ts
+++ b/src/lib/vm.ts
@@ -271,9 +271,6 @@ export async function registerVM(program: Command) {
           ? formatTimestampToISO(options.since)
           : "";
 
-        // Set ascending order for tailing
-        params.append("order", "asc");
-
         // Initial fetch (if --since not provided, we get the latest logs)
         if (!sinceTimestamp) {
           const data = await fetchLogs(params);


### PR DESCRIPTION
- **vm.ts: rm unused order param**
- **vm.ts: rm params.append(before|since) - it has no effect**
