### PR TITLE
Enhance version check and upgrade command functionality

### DIFF
--- a/src/checkVersion.ts
+++ b/src/checkVersion.ts
@@ -93,6 +93,11 @@ async function checkProductionCLIVersion() {
 }
 
 export async function checkVersion() {
+  // Disable auto-upgrade if env var is set
+  if (process.env.SF_CLI_DISABLE_AUTO_UPGRADE) {
+    return;
+  }
+
   // Skip version check if running upgrade command
   const args = process.argv.slice(2);
   if (args[0] === "upgrade") return;
@@ -108,6 +113,9 @@ export async function checkVersion() {
   const currentIsStable = !semver.prerelease(version);
   const latestIsPrerelease = semver.prerelease(latestVersion);
   if (currentIsStable && latestIsPrerelease) return;
+
+  // Don't upgrade automatically if on prerelease
+  if (semver.prerelease(version)) return;
 
   const isOutdated = semver.lt(version, latestVersion);
   if (!isOutdated) return;

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -1,6 +1,6 @@
 import type { Command } from "@commander-js/extra-typings";
-import process from "node:process";
 import * as console from "node:console";
+import process from "node:process";
 import ora from "ora";
 
 /**
@@ -30,8 +30,9 @@ export function registerUpgrade(program: Command) {
   return program
     .command("upgrade")
     .argument("[version]", "The version to upgrade to")
+    .option("-f, --force", "Force upgrade even if already on specified version")
     .description("Upgrade to the latest version or a specific version")
-    .action(async (version) => {
+    .action(async (version, options) => {
       const spinner = ora();
       const currentVersion = program.version();
 
@@ -49,13 +50,13 @@ export function registerUpgrade(program: Command) {
       }
 
       // Check if user has already installed latest version.
-      if (version === currentVersion) {
+      if (version === currentVersion && !options.force) {
         spinner.succeed(`You are already on version ${currentVersion}.`);
         return;
       }
 
       const isOnLatestVersion = await getIsOnLatestVersion(currentVersion);
-      if (isOnLatestVersion) {
+      if (isOnLatestVersion && !version && !options.force) {
         spinner.succeed(
           `You are already on the latest version (${currentVersion}).`,
         );


### PR DESCRIPTION
- Disable auto-upgrade if the environment variable SF_CLI_DISABLE_AUTO_UPGRADE is set.
- Prevent automatic upgrades when on a prerelease version.
- Add a force option to the upgrade command to allow upgrades even if the current version matches the specified version.