### PR TITLE
feat: disable auto-upgrade based on environment variable

### DIFF
--- a/src/checkVersion.ts
+++ b/src/checkVersion.ts
@@ -93,6 +93,11 @@ async function checkProductionCLIVersion() {
 }
 
 export async function checkVersion() {
+  // Disable auto-upgrade if env var is set
+  if (process.env.SF_CLI_DISABLE_AUTO_UPGRADE) {
+    return;
+  }
+
   // Skip version check if running upgrade command
   const args = process.argv.slice(2);
   if (args[0] === "upgrade") return;


### PR DESCRIPTION
Added a check to skip the auto-upgrade process if the environment variable SF_CLI_DISABLE_AUTO_UPGRADE is set. This allows users to control the upgrade behavior of the CLI more effectively.