### PR TITLE
consistent ssh known_hosts value with multiple proxies

### DIFF
--- a/src/lib/ssh.ts
+++ b/src/lib/ssh.ts
@@ -103,6 +103,7 @@ export function registerSsh(program: Command) {
         cmd = cmd.concat(["-o", `KnownHostsCommand=${knownHostsCommand_str}`]);
       }
 
+      cmd = cmd.concat(["-o", `HostKeyAlias=${vmId}.vms.sfcompute.dev`]);
       cmd = cmd.concat([sshDestination]);
 
       let shescape: undefined | Shescape = undefined;


### PR DESCRIPTION
I was annoyed that I kept seeing the same

```text
The authenticity of host '[64.78.177.245]:2479' can't be established.
ED25519 key fingerprint is SHA256:3Q/ZMffE4IaRCX3D2TzFDTA1h33fzopmFA7Rq2Mi1vk.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```

prompt as it would rotate through the multiple proxy IPs. This small change fixes that by using a consistent value to look up in the ~/.ssh/known_hosts file.

It does not appear that `CheckHostIP=no` is needed.