### PR TITLE
fix(quote): setQuote before we setLoading = false

### DIFF
--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -176,8 +176,8 @@ export function QuoteComponent(props: { options: SfBuyOptions }) {
   useEffect(() => {
     (async () => {
       const quote = await getQuoteFromParsedSfBuyOptions(props.options);
-      setIsLoading(false);
       if (quote) setQuote(quote);
+      setIsLoading(false);
     })();
   }, [props.options]);
 


### PR DESCRIPTION
Since we're single threaded, it is possible that:

- we setLoading(false)
- this updates the component rendered (however, at this point we haven't
  set quote yet)
- So we tell the user that there's no quote
- then the if (quote) setQuote(quote) runs
- TUI updtes to reflect the quote.

From the users point of view we've told them there's no quote and
immediately given them a quote.

In this commit we setQuote before setLoading so they don't see this ui
blip.
