### PR TITLE
feat: [PRODUCT-347] add better examples to the help text for sf scale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
       - run: deno install
       - run: deno fmt --check
       - run: deno lint
-      - run: deno check --config deno.json ./src/index.ts
+      - run: deno check --config deno.json .
       - run: deno test --allow-all

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -29,6 +29,9 @@ import { Row } from "../Row.tsx";
 import { GPUS_PER_NODE } from "../constants.ts";
 import { parseAccelerators } from "../index.ts";
 import { analytics } from "../posthog.ts";
+import console from "node:console";
+import process from "node:process";
+import chalk from "chalk";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -39,6 +42,7 @@ export function _registerBuy(program: Command) {
   return program
     .command("buy")
     .description("Place a buy order")
+    .showHelpAfterError()
     .requiredOption("-t, --type <type>", "Type of GPU", "h100i")
     .option(
       "-n, --accelerators <quantity>",
@@ -72,7 +76,11 @@ export function _registerBuy(program: Command) {
     .hook("preAction", (command) => {
       const { duration, end } = command.opts();
       if ((!duration && !end) || (!!duration && !!end)) {
-        logAndQuit("Specify either --duration or --end, but not both");
+        console.error(
+          chalk.yellow("Specify either --duration or --end, but not both"),
+        );
+        command.help();
+        process.exit(1);
       }
     })
     .option("-y, --yes", "Automatically confirm the order")

--- a/src/lib/clusters/mock.ts
+++ b/src/lib/clusters/mock.ts
@@ -9,7 +9,8 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     name: "upcoming-single-cluster",
     kubernetes_namespace: "default",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
-    contract: MOCK_CONTRACTS[0] as UserFacingCluster["contract"], // upcoming-single contract
+    contract: MOCK_CONTRACTS[0] as UserFacingCluster["contract"], // upcoming-single contract,
+    state: "Upcoming",
   },
 
   // 2. Cluster with active multi-order contract
@@ -20,6 +21,7 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     kubernetes_namespace: "prod",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
     contract: MOCK_CONTRACTS[1] as UserFacingCluster["contract"], // active-multi contract
+    state: "Active",
   },
 
   // 3. Cluster with upcoming multi-order contract
@@ -30,6 +32,7 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     kubernetes_namespace: "staging",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
     contract: MOCK_CONTRACTS[2] as UserFacingCluster["contract"], // upcoming-multi contract
+    state: "Upcoming",
   },
 
   // 4. Cluster with expired contract
@@ -40,6 +43,7 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     kubernetes_namespace: "default",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
     contract: MOCK_CONTRACTS[3] as UserFacingCluster["contract"], // expired contract
+    state: "Expired",
   },
 
   // 5. Cluster with mixed state contract
@@ -50,6 +54,7 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     kubernetes_namespace: "mixed",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
     contract: MOCK_CONTRACTS[4] as UserFacingCluster["contract"], // mixed-states contract
+    state: "Active",
   },
 
   // 6. Cluster with colocated contract
@@ -60,6 +65,7 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     kubernetes_namespace: "colocated",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
     contract: MOCK_CONTRACTS[5] as UserFacingCluster["contract"], // colocated contract
+    state: "Active",
   },
 
   // 7. Cluster without contract (for testing non-contract clusters)
@@ -69,5 +75,6 @@ export const MOCK_CLUSTERS: UserFacingCluster[] = [
     name: "no-contract-cluster",
     kubernetes_namespace: "default",
     kubernetes_ca_cert: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
+    state: "Active",
   },
 ];

--- a/src/lib/scale/create.tsx
+++ b/src/lib/scale/create.tsx
@@ -270,7 +270,7 @@ $ sf scale create -n 8
 $ sf scale create -n 32 -p 1.50
 
 \x1b[2m# Maintain 8 GPUs, start buying the next reservation when there's 30 minutes left\x1b[0m
-$ sf scale create -n 8 -d '30m'
+$ sf scale create -n 8 --horizon '30m'
 `,
   )
   .showHelpAfterError()

--- a/src/lib/scale/create.tsx
+++ b/src/lib/scale/create.tsx
@@ -258,7 +258,22 @@ function CreateProcurementCommand(props: CreateProcurementCommandProps) {
 }
 
 const create = new Command("create")
-  .description("create a procurement to purchase the desired number of GPUs.")
+  .description("Create a procurement to purchase the desired number of GPUs.")
+  .addHelpText(
+    "after",
+    `
+Examples:
+\x1b[2m# Create a new procurement for 8 GPUs\x1b[0m
+$ sf scale create -n 8
+
+\x1b[2m# Maintain 32 GPUs, but only while the price is <= $1.50/GPU/hr\x1b[0m
+$ sf scale create -n 32 -p 1.50
+
+\x1b[2m# Maintain 8 GPUs, start buying the next reservation when there's 30 minutes left\x1b[0m
+$ sf scale create -n 8 -d '30m'
+`,
+  )
+  .showHelpAfterError()
   .requiredOption(
     "-n, --accelerators <accelerators>",
     "desired number of GPUs (0 to turn off)",

--- a/src/lib/scale/index.tsx
+++ b/src/lib/scale/index.tsx
@@ -13,6 +13,7 @@ export async function registerScale(program: Command) {
     .command("scale")
     .alias("procurements")
     .alias("procurement")
+    .showHelpAfterError()
     .description(
       "Create and manage procurements that purchase a desired number of GPUs on a rolling basis.",
     )
@@ -20,6 +21,25 @@ export async function registerScale(program: Command) {
       "after",
       `
 A procurement is an automated purchasing strategy that will attempt to constantly maintain a desired number of GPUs by buying and selling spot reservations.
+
+Examples:
+\x1b[2m# Create a new procurement for 8 GPUs\x1b[0m
+$ sf scale create -n 8
+
+\x1b[2m# List your procurements\x1b[0m
+$ sf scale ls [procurement-id...]
+
+\x1b[2m# Scale procurements to 16 GPUs\x1b[0m
+$ sf scale update <procurement-id...> -n 16
+
+\x1b[2m# Turn off procurements by scaling to 0\x1b[0m
+$ sf scale update <procurement-id...> -n 0
+
+\x1b[2m# Update the limit price of procurements to $1.50/GPU/hr\x1b[0m
+$ sf scale update <procurement-id...> -p 1.50
+
+\x1b[2m# Start reserving more time 30 minutes before GPUs expire\x1b[0m
+$ sf scale update <procurement-id...> -d '30m'
 
 See https://docs.sfcompute.com/docs/using-sf-scale for more information.
     `,

--- a/src/lib/scale/index.tsx
+++ b/src/lib/scale/index.tsx
@@ -39,7 +39,7 @@ $ sf scale update <procurement-id...> -n 0
 $ sf scale update <procurement-id...> -p 1.50
 
 \x1b[2m# Start reserving more time 30 minutes before GPUs expire\x1b[0m
-$ sf scale update <procurement-id...> -d '30m'
+$ sf scale update <procurement-id...> --horizon '30m'
 
 See https://docs.sfcompute.com/docs/using-sf-scale for more information.
     `,

--- a/src/lib/scale/list.tsx
+++ b/src/lib/scale/list.tsx
@@ -59,7 +59,7 @@ function ProcurementsList(props: { type?: string; ids?: string[] }) {
           settled.forEach((result, idx) => {
             if (result.status === "fulfilled" && result.value !== null) {
               fetchedProcurements.push(result.value);
-            } else if (props.ids) {
+            } else {
               failed.push({
                 id: props.ids[idx],
                 message: result.status === "rejected"

--- a/src/lib/scale/list.tsx
+++ b/src/lib/scale/list.tsx
@@ -49,9 +49,10 @@ function ProcurementsList(props: { type?: string; ids?: string[] }) {
         let fetchedProcurements: Procurement[] = [];
 
         // Fetch procurements either by specific IDs or list all
-        if (props.ids?.length && props.ids.length > 0) {
+        const { ids = [], type } = props;
+        if (ids.length > 0) {
           const settled = await Promise.allSettled(
-            props.ids.map((id) => getProcurement({ id })),
+            ids.map((id) => getProcurement({ id })),
           );
 
           const failed: { id: string; message: string }[] = [];
@@ -61,7 +62,7 @@ function ProcurementsList(props: { type?: string; ids?: string[] }) {
               fetchedProcurements.push(result.value);
             } else {
               failed.push({
-                id: props.ids[idx],
+                id: ids[idx],
                 message: result.status === "rejected"
                   ? (result.reason instanceof Error
                     ? result.reason.message
@@ -77,8 +78,8 @@ function ProcurementsList(props: { type?: string; ids?: string[] }) {
         }
 
         // Apply type filter if provided
-        const finalProcurements = props.type
-          ? fetchedProcurements.filter((p) => p.instance_type === props.type)
+        const finalProcurements = type
+          ? fetchedProcurements.filter((p) => p.instance_type === type)
           : fetchedProcurements;
 
         setProcurements(finalProcurements);

--- a/src/lib/scale/list.tsx
+++ b/src/lib/scale/list.tsx
@@ -113,7 +113,22 @@ function ProcurementsList(props: { type?: string; ids?: string[] }) {
 const show = new Command("show")
   .alias("list")
   .alias("ls")
-  .description("show active and disabled procurements")
+  .addHelpText(
+    "after",
+    `
+Examples:
+\x1b[2m# List all procurements\x1b[0m
+$ sf scale ls
+
+\x1b[2m# Show a specific procurement by ID\x1b[0m
+$ sf scale show <procurement_id>
+
+\x1b[2m# List all procurements of a specific node type\x1b[0m
+$ sf scale list -t h100i
+`,
+  )
+  .showHelpAfterError()
+  .description("Show active and disabled procurements")
   .argument("[ID...]", "show a specific procurement by ID")
   .option("-t, --type <type>", "show procurements of a specific node type")
   .action((ids, options) => {

--- a/src/lib/scale/update.tsx
+++ b/src/lib/scale/update.tsx
@@ -25,6 +25,8 @@ import {
   parsePriceArg,
   type Procurement,
 } from "./utils.ts";
+import console from "node:console";
+import chalk from "chalk";
 
 async function updateProcurement({
   procurementId,
@@ -110,7 +112,7 @@ function useUpdateProcurements() {
 
 type UpdateProcurementCommandProps = {
   ids: string[];
-  accelerators: number;
+  accelerators?: number;
   horizon?: number;
   price?: number;
   yes?: boolean;
@@ -130,9 +132,15 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
     return { successfulProcurements };
   }, [procurements]);
   const [confirmationMessage, setConfirmationMessage] = useState<ReactNode>();
-  const nodesRequired = useMemo(() => acceleratorsToNodes(props.accelerators), [
-    props.accelerators,
-  ]);
+  const nodesRequired = useMemo(
+    () =>
+      props.accelerators !== undefined
+        ? acceleratorsToNodes(props.accelerators)
+        : undefined,
+    [
+      props.accelerators,
+    ],
+  );
 
   const [displayedPricePerGpuHourInCents, setDisplayedPricePerGpuHourInCents] =
     useState<number>();
@@ -199,10 +207,11 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
                           p.buy_limit_price_per_gpu_hour
                         ? undefined
                         : props.price}
-                      accelerators={acceleratorsToNodes(props.accelerators) ===
-                          p.desired_quantity
-                        ? undefined
-                        : props.accelerators}
+                      accelerators={props.accelerators !== undefined &&
+                          acceleratorsToNodes(props.accelerators) !==
+                            p.desired_quantity
+                        ? props.accelerators
+                        : undefined}
                       update
                     />
                   </Box>
@@ -215,7 +224,7 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
                   {failedToFetch.map(([message, id]) => (
                     <Box key={id} flexDirection="column">
                       <Text color="red">
-                        - {message}
+                        - {message} ({id})
                       </Text>
                     </Box>
                   ))}
@@ -240,7 +249,6 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
       exit();
       return;
     }
-
     updateProcurements(
       successfulProcurements.map((p) => p.id),
       {
@@ -284,8 +292,7 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
       <Box flexDirection="column" gap={1}>
         {successfulProcurements && successfulProcurements.length > 0 && (
           <Text color="green">
-            Successfully updated {successfulProcurements.length}{" "}
-            procurement(s) to {props.accelerators} GPUs.
+            Successfully updated {successfulProcurements.length} procurement(s).
           </Text>
         )}
         {failedProcurements && failedProcurements.length > 0 && (
@@ -327,9 +334,24 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
 }
 
 const update = new Command("update")
-  .description("update a procurement.")
+  .description("Update a procurement.")
+  .addHelpText(
+    "after",
+    `
+Examples:
+\x1b[2m# Scale a procurement to 16 GPUs\x1b[0m
+$ sf scale update <procurement_id> -n 16
+
+\x1b[2m# Disable a procurement (scale to 0 GPUs)\x1b[0m
+$ sf scale update <procurement_id> -n 0
+
+\x1b[2m# Update the limit price of a procurement to $1.50/GPU/hr\x1b[0m
+$ sf scale update <procurement_id> -p 1.50
+`,
+  )
+  .showHelpAfterError()
   .argument("<procurement_id...>", "ID of the procurement to update")
-  .requiredOption(
+  .option(
     "-n, --accelerators <accelerators>",
     "desired number of GPUs (0 to turn off)",
     parseAccelerators,
@@ -346,6 +368,15 @@ const update = new Command("update")
   )
   .option("-y, --yes", "automatically confirm the command.")
   .action((id, options) => {
+    if (Object.keys(options).length === 0) {
+      console.error(
+        chalk.yellow(
+          "No options provided. Please provide at least one option.\n",
+        ),
+      );
+      update.help();
+      return;
+    }
     render(
       <UpdateProcurementCommand
         {...options}

--- a/src/lib/scale/update.tsx
+++ b/src/lib/scale/update.tsx
@@ -339,14 +339,14 @@ const update = new Command("update")
     "after",
     `
 Examples:
-\x1b[2m# Scale a procurement to 16 GPUs\x1b[0m
-$ sf scale update <procurement_id> -n 16
+\x1b[2m# Scale procurements to 16 GPUs\x1b[0m
+$ sf scale update <procurement_id...> -n 16
 
-\x1b[2m# Disable a procurement (scale to 0 GPUs)\x1b[0m
-$ sf scale update <procurement_id> -n 0
+\x1b[2m# Disable procurements (scale to 0 GPUs)\x1b[0m
+$ sf scale update <procurement_id...> -n 0
 
-\x1b[2m# Update the limit price of a procurement to $1.50/GPU/hr\x1b[0m
-$ sf scale update <procurement_id> -p 1.50
+\x1b[2m# Update the limit price of procurements to $1.50/GPU/hr\x1b[0m
+$ sf scale update <procurement_id...> -p 1.50
 `,
   )
   .showHelpAfterError()

--- a/src/lib/sell/index.tsx
+++ b/src/lib/sell/index.tsx
@@ -4,7 +4,7 @@ import dayjs from "npm:dayjs@1.11.13";
 import duration from "npm:dayjs@1.11.13/plugin/duration.js";
 import relativeTime from "npm:dayjs@1.11.13/plugin/relativeTime.js";
 import { apiClient } from "../../apiClient.ts";
-import { paths } from "../../schema.ts";
+import { components } from "../../schema.ts";
 import {
   logAndQuit,
   logLoginMessageAndQuit,
@@ -25,10 +25,7 @@ import invariant from "tiny-invariant";
 import { getContract } from "../../helpers/fetchers.ts";
 import { isLoggedIn } from "../../helpers/config.ts";
 
-type SellOrderFlags =
-  paths["/v0/orders"]["post"]["requestBody"]["content"]["application/json"][
-    "flags"
-  ];
+type SellOrderFlags = components["schemas"]["PostOrderRequest"]["flags"];
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);


### PR DESCRIPTION
Updates `sf scale` command and subcommands to follow https://clig.dev/#help.

Adds examples to `sf scale`, `sf scale create`, `sf scale update`, and `sf scale list`.

Makes `sf list` gracefully fail.

Also makes `sf scale` and `sf buy` display help text on error. This makes them follow "Display help text when passed no options".

