### PR TITLE
feat: [PRODUCT-409] show human friendly instance type in `sf scale`

### DIFF
--- a/src/lib/Row.tsx
+++ b/src/lib/Row.tsx
@@ -1,17 +1,22 @@
 import { Box, Text } from "ink";
 import React from "react";
 
-export function Row(props: {
+export function Row({
+  head,
+  value,
+  headWidth,
+}: {
   head: string;
-  value: string;
+  value: string | React.ReactNode;
   headWidth?: number;
 }) {
+  const valueIsString = typeof value === "string";
   return (
     <Box>
-      <Box width={props.headWidth}>
-        <Text dimColor>{props.head}</Text>
+      <Box width={headWidth}>
+        <Text dimColor>{head}</Text>
       </Box>
-      <Text>{props.value}</Text>
+      {valueIsString ? <Text>{value}</Text> : value}
     </Box>
   );
 }

--- a/src/lib/scale/ConfirmationMessage.tsx
+++ b/src/lib/scale/ConfirmationMessage.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Box, Text } from "ink";
 
+import { InstanceTypeMetadata } from "../../helpers/instance-types-meta.ts";
+
 import { Row } from "../Row.tsx";
 import { formatDuration } from "../orders/index.tsx";
 
@@ -22,7 +24,11 @@ export default function ConfirmationMessage(props: {
   const horizonInMilliseconds = props.horizonMinutes
     ? Math.max(props.horizonMinutes, MIN_CONTRACT_MINUTES) * 60 * 1000
     : undefined;
-
+  const isSupportedType = typeof props.type === "string" &&
+    props.type in InstanceTypeMetadata;
+  const typeLabel = isSupportedType
+    ? InstanceTypeMetadata[props.type!].displayName
+    : props.type;
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box gap={1}>
@@ -34,7 +40,16 @@ export default function ConfirmationMessage(props: {
       <Row
         headWidth={30}
         head="Type"
-        value={props.type ?? "unchanged"}
+        value={isSupportedType
+          ? (
+            <Box gap={1}>
+              <Text>{typeLabel}</Text>
+              <Text dimColor>
+                ({props.type})
+              </Text>
+            </Box>
+          )
+          : props.type}
       />
       <Row
         headWidth={30}

--- a/src/lib/scale/ConfirmationMessage.tsx
+++ b/src/lib/scale/ConfirmationMessage.tsx
@@ -42,11 +42,9 @@ export default function ConfirmationMessage(props: {
         head="Type"
         value={isSupportedType
           ? (
-            <Box gap={1}>
+            <Box minWidth={30} justifyContent="space-between">
               <Text>{typeLabel}</Text>
-              <Text dimColor>
-                ({props.type})
-              </Text>
+              <Text dimColor>({props.type})</Text>
             </Box>
           )
           : "unchanged"}
@@ -62,9 +60,14 @@ export default function ConfirmationMessage(props: {
         headWidth={30}
         head="Limit Price"
         value={props.pricePerGpuHourInCents !== undefined
-          ? `$${(props.pricePerGpuHourInCents / 100).toFixed(2)}/gpu/hr${
-            props.quote ? " (1.5x market)" : ""
-          }`
+          ? (
+            <Box minWidth={30} justifyContent="space-between">
+              <Text>
+                ${(props.pricePerGpuHourInCents / 100).toFixed(2)}/gpu/hr
+              </Text>
+              {props.quote && <Text dimColor>(1.5x market)</Text>}
+            </Box>
+          )
           : "unchanged"}
       />
       <Row

--- a/src/lib/scale/ConfirmationMessage.tsx
+++ b/src/lib/scale/ConfirmationMessage.tsx
@@ -49,7 +49,7 @@ export default function ConfirmationMessage(props: {
               </Text>
             </Box>
           )
-          : props.type}
+          : "unchanged"}
       />
       <Row
         headWidth={30}

--- a/src/lib/scale/ConfirmationMessage.tsx
+++ b/src/lib/scale/ConfirmationMessage.tsx
@@ -60,13 +60,11 @@ export default function ConfirmationMessage(props: {
       />
       <Row
         headWidth={30}
-        head={`Limit Price${
-          (props.quote && props.pricePerGpuHourInCents !== undefined)
-            ? " (1.5 x market)"
-            : ""
-        }`}
+        head="Limit Price"
         value={props.pricePerGpuHourInCents !== undefined
-          ? `$${(props.pricePerGpuHourInCents / 100).toFixed(2)}/gpu/hr`
+          ? `$${(props.pricePerGpuHourInCents / 100).toFixed(2)}/gpu/hr${
+            props.quote ? " (1.5x market)" : ""
+          }`
           : "unchanged"}
       />
       <Row

--- a/src/lib/scale/ConfirmationMessage.tsx
+++ b/src/lib/scale/ConfirmationMessage.tsx
@@ -42,7 +42,11 @@ export default function ConfirmationMessage(props: {
         head="Type"
         value={isSupportedType
           ? (
-            <Box minWidth={30} justifyContent="space-between">
+            <Box
+              gap={1}
+              minWidth={props.quote ? 30 : undefined}
+              justifyContent="space-between"
+            >
               <Text>{typeLabel}</Text>
               <Text dimColor>({props.type})</Text>
             </Box>
@@ -61,7 +65,7 @@ export default function ConfirmationMessage(props: {
         head="Limit Price"
         value={props.pricePerGpuHourInCents !== undefined
           ? (
-            <Box minWidth={30} justifyContent="space-between">
+            <Box gap={1} minWidth={30} justifyContent="space-between">
               <Text>
                 ${(props.pricePerGpuHourInCents / 100).toFixed(2)}/gpu/hr
               </Text>

--- a/src/lib/scale/ProcurementDisplay.tsx
+++ b/src/lib/scale/ProcurementDisplay.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Box, Text } from "ink";
 import { Badge } from "@inkjs/ui";
 
+import { InstanceTypeMetadata } from "../../helpers/instance-types-meta.ts";
+
 import { Row } from "../Row.tsx";
 import { GPUS_PER_NODE } from "../constants.ts";
 import { formatDuration } from "../orders/index.tsx";
@@ -43,7 +45,10 @@ export default function ProcurementDisplay(
   const horizonMinutes = horizon;
   const quantity = desired_quantity * GPUS_PER_NODE;
   const pricePerGpuHourInCents = buy_limit_price_per_gpu_hour;
-
+  const isSupportedType = instance_type in InstanceTypeMetadata;
+  const typeLabel = isSupportedType
+    ? InstanceTypeMetadata[instance_type].displayName
+    : instance_type;
   return (
     <Box flexDirection="column">
       <ProcurementHeader id={id} quantity={quantity} />
@@ -51,7 +56,16 @@ export default function ProcurementDisplay(
         <Row
           headWidth={15}
           head="Type"
-          value={instance_type}
+          value={isSupportedType
+            ? (
+              <Box gap={1}>
+                <Text>{typeLabel}</Text>
+                <Text dimColor>
+                  ({instance_type})
+                </Text>
+              </Box>
+            )
+            : instance_type}
         />
         <Row headWidth={15} head="GPUs" value={String(quantity)} />
         <Row

--- a/src/lib/scale/list.tsx
+++ b/src/lib/scale/list.tsx
@@ -96,7 +96,7 @@ function ProcurementsList(props: { type?: string; ids?: string[] }) {
 
   if (isLoading) {
     return (
-      <Box>
+      <Box gap={1}>
         <Spinner type="arc" />
         <Text>Fetching procurement details...</Text>
       </Box>


### PR DESCRIPTION
`sf scale create`
<img width="997" alt="Screenshot 2025-05-14 at 3 02 25 PM" src="https://github.com/user-attachments/assets/28e1aeba-e1e5-4486-82e1-afdb79477b6b" />
<img width="477" alt="Screenshot 2025-05-14 at 3 06 47 PM" src="https://github.com/user-attachments/assets/d75a3a57-7752-46ef-a58c-4321292ec098" />

`sf scale ls`
<img width="401" alt="Screenshot 2025-05-13 at 1 04 23 AM" src="https://github.com/user-attachments/assets/b045d95a-d5d1-49bf-b054-e756db3c0ab8" />

`sf scale update`
<img width="470" alt="Screenshot 2025-05-14 at 3 05 41 PM" src="https://github.com/user-attachments/assets/129aebe8-c74c-4d00-9a2e-222896c75439" />

