### PR TITLE
fix: vcluster credentials verification logic

### DIFF
--- a/src/lib/clusters/clusters.tsx
+++ b/src/lib/clusters/clusters.tsx
@@ -325,7 +325,9 @@ async function listClusterUsers({ token }: { token?: string }) {
   }> = [];
   for (const k of k8s) {
     const is_usable: boolean = Boolean(
-      k.encrypted_token && k.nonce && k.ephemeral_pubkey,
+      (k.encrypted_token && k.nonce && k.ephemeral_pubkey) ||
+        (k.encrypted_kubeconfig && k.nonce && k.ephemeral_pubkey &&
+          k.cluster_type === "vcluster"),
     );
     if (k.id) {
       users.push({


### PR DESCRIPTION
### Context 
Vaid vcluster credentials were being marked as not ready by the CLI and a customer noticed it:

https://sfcompute.slack.com/archives/C079B9UE2LE/p1750872799183859


### What changed?

Modified the `is_usable` boolean check in the `listClusterUsers` function to consider a cluster as usable if it's a vcluster type with encrypted_kubeconfig, nonce, and ephemeral_pubkey properties.

