### PR TITLE
refactor: [PRODUCT-465] use `logs2` instead of `logs` REST endpoint

### DIFF
--- a/src/lib/vm.ts
+++ b/src/lib/vm.ts
@@ -36,7 +36,7 @@ function formatTimestampToISO(timestamp: string): string {
     throw new CommanderError(
       1,
       "INVALID_TIMESTAMP_FORMAT",
-      "Invalid timestamp format: ${timestamp}. Please use RFC3339 format (e.g., 2023-01-01T00:00:00Z)",
+      `Invalid timestamp format: ${timestamp}. Please use RFC3339 format (e.g., 2023-01-01T00:00:00Z)`,
     );
   }
   return date.toISOString();

--- a/src/lib/vm.ts
+++ b/src/lib/vm.ts
@@ -228,7 +228,6 @@ Examples:
       // State for handling incomplete lines across chunks
       let incompleteLine = "";
       let lastTimestamp = "";
-      let totalLogs = 0;
 
       // Function to process and print logs
       function processLogs(logs: VMLogsResponse) {
@@ -255,7 +254,6 @@ Examples:
               console.log(`${prefix} ${line}`);
             }
           }
-          totalLogs += logs.length;
         }
       }
 


### PR DESCRIPTION
Reimplement `vm logs` using `v0/logs2` instead of `v0/logs`.