### PR TITLE
fix: support explicitly `disabled` procurements

### DIFF
--- a/src/lib/scale/ProcurementDisplay.tsx
+++ b/src/lib/scale/ProcurementDisplay.tsx
@@ -10,19 +10,21 @@ import { formatDuration } from "../orders/index.tsx";
 
 import { formatColocationStrategy, Procurement } from "./utils.ts";
 
-export function ProcurementHeader({ id, quantity }: {
+export function ProcurementHeader({ id, quantity, status }: {
   id: string;
   quantity: number;
+  status: Procurement["status"];
 }) {
+  const isActive = quantity > 0 && status === "active";
   return (
     <Box gap={1}>
       <Box width={11}>
-        {quantity > 0
+        {isActive
           ? <Badge color="cyan">Active</Badge>
           : <Badge color="gray">Disabled</Badge>}
       </Box>
       <Box paddingLeft={0.1}>
-        <Text color={quantity > 0 ? "cyan" : "gray"}>
+        <Text color={isActive ? "cyan" : "gray"}>
           {id}
         </Text>
       </Box>
@@ -35,6 +37,7 @@ export default function ProcurementDisplay(
     procurement: {
       id,
       instance_type,
+      status,
       desired_quantity,
       buy_limit_price_per_gpu_hour,
       horizon,
@@ -51,7 +54,7 @@ export default function ProcurementDisplay(
     : instance_type;
   return (
     <Box flexDirection="column">
-      <ProcurementHeader id={id} quantity={quantity} />
+      <ProcurementHeader id={id} quantity={quantity} status={status} />
       <Box flexDirection="column" paddingTop={0.5}>
         <Row
           headWidth={15}

--- a/src/lib/scale/update.tsx
+++ b/src/lib/scale/update.tsx
@@ -191,6 +191,7 @@ function UpdateProcurementCommand(props: UpdateProcurementCommandProps) {
                     <ProcurementHeader
                       id={p.id}
                       quantity={p.desired_quantity}
+                      status={p.status}
                     />
                     <ConfirmationMessage
                       key={p.id}


### PR DESCRIPTION
Customer reported an issue where `disabled` procurements (procurements disabled using the API) do not render as `disabled` in `sf procurements ls`