### PR TITLE
feat: [PRODUCT-545] educate the user about Nodes -> VMs + other iteration

### DIFF
--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -117,15 +117,15 @@ const create = new Command("create")
   .addHelpText(
     "after",
     `
-Examples:
+Examples:\n
   \x1b[2m# Create a single node with a specific name\x1b[0m
-  $ sf nodes create node-1 --zone alamo --max-price 12.50
+  $ sf nodes create node-1 --zone hayesvalley --max-price 12.50
 
   \x1b[2m# Create multiple nodes with specific names\x1b[0m
   $ sf nodes create node-1 node-2 node-3 --zone hayesvalley --max-price 9
 
   \x1b[2m# Create 3 nodes with auto-generated names\x1b[0m
-  $ sf nodes create -n 3 --zone seacliff --max-price 10.00
+  $ sf nodes create -n 3 --zone hayesvalley --max-price 10.00
 
   \x1b[2m# Create a reserved node with specific start/end times\x1b[0m
   $ sf nodes create node-1 --start "2024-01-15T10:00:00Z" --end "2024-01-15T12:00:00Z"

--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -8,11 +8,13 @@ import type { SFCNodes } from "@sfcompute/nodes-sdk-alpha";
 
 import {
   createNodesTable,
+  determineNodeType,
   durationOption,
   endOption,
   forceOption,
   jsonOption,
   maxPriceOption,
+  pluralizeNodes,
   startOption,
   zoneOption,
 } from "./utils.ts";
@@ -21,6 +23,20 @@ import { logAndQuit } from "../../helpers/errors.ts";
 import { getPricePerGpuHourFromQuote, getQuote } from "../buy/index.tsx";
 import { roundEndDate } from "../../helpers/units.ts";
 import { GPUS_PER_NODE } from "../constants.ts";
+
+/**
+ * Create a formatted node type description with count
+ * @param count Number of nodes
+ * @param nodeType Type of node ("spot" or "reserved")
+ * @returns Formatted string like "1 spot node" or "3 reserved nodes"
+ */
+function formatNodeDescription(
+  count: number,
+  nodeType: "reserved" | "spot",
+): string {
+  const plural = pluralizeNodes(count);
+  return `${count} ${nodeType} ${plural}`;
+}
 
 /**
  * Validates that a count value is a positive integer
@@ -41,7 +57,7 @@ function validateCount(val: string): number {
 }
 
 const create = new Command("create")
-  .description("Create one or more compute nodes")
+  .description("Create reserved or spot nodes")
   .showHelpAfterError()
   .argument(
     "[names...]",
@@ -75,7 +91,9 @@ const create = new Command("create")
     if (names.length > 0 && count) {
       if (names.length !== count) {
         console.error(red(
-          `You specified ${names.length} node name(s) but \`--count\` is set to ${count}. The number of names must match the \`count\`.\n`,
+          `You specified ${names.length} ${
+            names.length === 1 ? "node name" : "node names"
+          } but \`--count\` is set to ${count}. The number of names must match the \`count\`.\n`,
         ));
         command.help();
         process.exit(1);
@@ -128,16 +146,22 @@ async function createNodesAction(
   try {
     const client = await nodesClient();
     const count = options.count ?? names.length;
-    const isReserved = !!(options.duration || options.end);
+    const nodeType = determineNodeType(options);
+    const isReserved = nodeType === "reserved";
 
     // Only show pricing and get confirmation if not using --force
     if (!options.force) {
       // Determine node type and prepare confirmation message
-      let confirmationMessage = `Create ${count} node(s)`;
+      let confirmationMessage = `Create ${
+        formatNodeDescription(count, nodeType)
+      }`;
 
       if (isReserved) {
         // Reserved nodes - get quote for accurate pricing
-        const spinner = ora(`Quoting ${count} node(s)...`).start();
+        const spinner = ora(
+          `Quoting ${formatNodeDescription(count, nodeType)}...`,
+        )
+          .start();
 
         // Calculate duration for quote
         let durationSeconds: number = 3600; // Default 1 hour
@@ -211,7 +235,7 @@ async function createNodesAction(
       if (!confirmed) process.exit(0);
     }
 
-    const spinner = ora(`Creating ${count} node(s)...`)
+    const spinner = ora(`Creating ${formatNodeDescription(count, nodeType)}...`)
       .start();
 
     try {
@@ -255,7 +279,11 @@ async function createNodesAction(
 
       const { data: createdNodes } = await client.nodes.create(createParams);
 
-      spinner.succeed(`Successfully created ${createdNodes.length} node(s)`);
+      spinner.succeed(
+        `Successfully created ${
+          formatNodeDescription(createdNodes.length, nodeType)
+        }`,
+      );
 
       if (options.json) {
         console.log(JSON.stringify(createdNodes, null, 2));

--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -299,14 +299,18 @@ async function createNodesAction(
         console.log(
           `  sf nodes list`,
         );
-        console.log(
-          `  sf nodes extend ${cyan(createdNodes?.[0]?.name ?? "my-node")}`,
-        );
-        console.log(
-          `  sf nodes set ${
-            cyan(createdNodes?.[0]?.name ?? "my-node")
-          } --max-price ${cyan("12.50")}`,
-        );
+        // Spot nodes can't be extended, so only suggest it for reserved nodes
+        if (isReserved) {
+          console.log(
+            `  sf nodes extend ${cyan(createdNodes?.[0]?.name ?? "my-node")}`,
+          );
+        } else {
+          console.log(
+            `  sf nodes set ${
+              cyan(createdNodes?.[0]?.name ?? "my-node")
+            } --max-price ${cyan("12.50")}`,
+          );
+        }
         console.log(
           `  sf nodes release ${cyan(createdNodes?.[0]?.name ?? "my-node")}`,
         );

--- a/src/lib/nodes/extend.ts
+++ b/src/lib/nodes/extend.ts
@@ -10,6 +10,7 @@ import {
   forceOption,
   jsonOption,
   maxPriceOption,
+  pluralizeNodes,
   requiredDurationOption,
 } from "./utils.ts";
 import SFCNodes from "npm:@sfcompute/nodes-sdk-alpha@latest";
@@ -60,7 +61,9 @@ async function extendNodeAction(
     if (!options.force) {
       // Get quote for accurate pricing preview
       const spinner = ora(
-        `Quoting extending ${nodeNames.length} node(s)...`,
+        `Quoting extending ${nodeNames.length} ${
+          pluralizeNodes(nodeNames.length)
+        }...`,
       ).start();
 
       // Add flexibility to duration for better quote matching (matches buy command logic)
@@ -85,9 +88,9 @@ async function extendNodeAction(
 
       spinner.stop();
 
-      let confirmationMessage = `Extend ${nodeNames.length} node(s) for ${
-        Math.round(durationSeconds / 3600 * 100) / 100
-      } hours`;
+      let confirmationMessage = `Extend ${nodeNames.length} ${
+        pluralizeNodes(nodeNames.length)
+      } for ${Math.round(durationSeconds / 3600 * 100) / 100} hours`;
 
       if (quote) {
         const pricePerGpuHour = getPricePerGpuHourFromQuote(quote);
@@ -108,7 +111,9 @@ async function extendNodeAction(
       if (!confirmed) process.exit(0);
     }
 
-    const spinner = ora(`Extending ${nodeNames.length} node(s)...`).start();
+    const spinner = ora(
+      `Extending ${nodeNames.length} ${pluralizeNodes(nodeNames.length)}...`,
+    ).start();
 
     const results: { name: string; node: SFCNodes.Node }[] = [];
     const errors: { name: string; error: string }[] = [];
@@ -128,7 +133,11 @@ async function extendNodeAction(
     }
 
     if (results.length > 0) {
-      spinner.succeed(`Successfully extended ${results.length} node(s)`);
+      spinner.succeed(
+        `Successfully extended ${results.length} ${
+          pluralizeNodes(results.length)
+        }`,
+      );
     }
 
     if (errors.length > 0) {
@@ -136,7 +145,9 @@ async function extendNodeAction(
         spinner.fail("Failed to extend any nodes");
       } else {
         spinner.warn(
-          `Extended ${results.length} node(s), but ${errors.length} failed`,
+          `Extended ${results.length} ${
+            pluralizeNodes(results.length)
+          }, but ${errors.length} failed`,
         );
       }
     }

--- a/src/lib/nodes/extend.ts
+++ b/src/lib/nodes/extend.ts
@@ -28,7 +28,7 @@ const extend = new Command("extend")
   .addHelpText(
     "after",
     `
-Examples:
+Examples:\n
   \x1b[2m# Extend a single node by 1 hour with max price $15/hour\x1b[0m
   $ sf nodes extend my-node --duration 1h --max-price 15.00
 

--- a/src/lib/nodes/index.ts
+++ b/src/lib/nodes/index.ts
@@ -22,7 +22,7 @@ export async function registerNodes(program: Command) {
 A node is a compute instance that provides GPUs for your workloads. Nodes can be created 
 as reservations (with specific start/end times) or as procurements (spot pricing).
 
-Examples:
+Examples:\n
 \x1b[2m# Create a single node\x1b[0m
 $ sf nodes create my-node
 
@@ -45,7 +45,7 @@ $ sf nodes extend my-node --duration 3600 --max-price 12.50
 $ sf nodes create -n 3
 
 \x1b[2m# Create nodes in a specific zone\x1b[0m
-$ sf nodes create my-node --zone alamo
+$ sf nodes create my-node --zone hayesvalley
     `,
     );
 

--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -15,6 +15,7 @@ import {
   createNodesTable,
   getStatusColor,
   jsonOption,
+  pluralizeNodes,
   printNodeType,
 } from "./utils.ts";
 
@@ -178,7 +179,9 @@ async function listNodesAction(options: ReturnType<typeof list.opts>) {
       console.log(createNodesTable(nodes));
       console.log(
         gray(
-          `\nFound ${nodes.length} node(s). Use --verbose for detailed information.`,
+          `\nFound ${nodes.length} ${
+            pluralizeNodes(nodes.length)
+          }. Use --verbose for detailed information, such as previous virtual machines.`,
         ),
       );
       console.log(gray("\nExamples:"));

--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -14,18 +14,200 @@ import { Row } from "../Row.tsx";
 import {
   createNodesTable,
   getStatusColor,
+  getVMStatusColor,
   jsonOption,
   pluralizeNodes,
   printNodeType,
 } from "./utils.ts";
+
+// Helper component to display VMs in a table format using Ink
+function VMTable({ vms }: { vms: NonNullable<SFCNodes.Node["vms"]>["data"] }) {
+  return (
+    <Box flexDirection="column" padding={0}>
+      {/* Header */}
+      <Box
+        padding={0}
+        marginY={0}
+        borderStyle="single"
+        borderBottom
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor="gray"
+      >
+        <Box width={25} padding={0}>
+          <Text bold color="cyan">Virtual Machines</Text>
+        </Box>
+        <Box width={15} padding={0}>
+          <Text bold color="cyan">Status</Text>
+        </Box>
+        <Box width={30} padding={0}>
+          <Text bold color="cyan">Start/End</Text>
+        </Box>
+      </Box>
+
+      {/* VM rows */}
+      {vms.map((vm) => {
+        const startDate = vm.start_at ? dayjs.unix(vm.start_at) : null;
+        const endDate = vm.end_at ? dayjs.unix(vm.end_at) : null;
+
+        let startEnd: string;
+        if (startDate && endDate) {
+          startEnd = `${startDate.format("YYYY-MM-DD HH:mm")} → ${
+            endDate.format("HH:mm")
+          }`;
+        } else if (startDate) {
+          startEnd = `${startDate.format("YYYY-MM-DD HH:mm")} → ?`;
+        } else {
+          startEnd = "Not available";
+        }
+
+        return (
+          <Box key={vm.id}>
+            <Box width={25} padding={0}>
+              <Text>{vm.id}</Text>
+            </Box>
+            <Box width={15} padding={0}>
+              <Text>{getVMStatusColor(vm.status)}</Text>
+            </Box>
+            <Box width={30} padding={0}>
+              <Text>{startEnd}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+// Helper function to get available actions for a node based on its status
+function getActionsForNode(node: SFCNodes.Node) {
+  const nodeActions: { label: string; command: string }[] = [];
+
+  // Get the last VM for logs/ssh commands
+  const lastVm = node.vms?.data?.sort((a, b) => b.updated_at - a.updated_at).at(
+    0,
+  );
+
+  switch (node.status) {
+    case "released":
+      // Released nodes: can view logs/ssh until the node ends
+      if (lastVm?.id) {
+        nodeActions.push(
+          { label: "Logs", command: `sf vms logs ${lastVm.id}` },
+        );
+        nodeActions.push({
+          label: "SSH",
+          command: `sf vms ssh ${lastVm.id}`,
+        });
+      }
+      nodeActions.push({
+        label: "Delete",
+        command: `sf nodes delete ${node.name} (coming soon)`,
+      });
+      break;
+
+    case "failed":
+    case "terminated":
+    case "deleted":
+      // No actions for ended nodes
+      break;
+
+    case "running":
+      // Running nodes
+      if (lastVm?.id) {
+        nodeActions.push(
+          { label: "Logs", command: `sf vms logs ${lastVm.id}` },
+          { label: "SSH", command: `sf vms ssh ${lastVm.id}` },
+        );
+      }
+
+      if (node.node_type === "reserved") {
+        // Reserved nodes: can extend or delete
+        nodeActions.push(
+          {
+            label: "Extend",
+            command:
+              `sf nodes extend ${node.name} --duration 60 --max-price 12.00`,
+          },
+          {
+            label: "Delete",
+            command: `sf nodes delete ${node.name} --force (coming soon)`,
+          },
+        );
+      } else if (node.node_type === "spot") {
+        // Spot nodes: can update, release, delete
+        nodeActions.push(
+          {
+            label: "Update",
+            command: `sf nodes set ${node.name} --max-price 12.50`,
+          },
+          { label: "Release", command: `sf nodes release ${node.name}` },
+          {
+            label: "Delete",
+            command: `sf nodes delete ${node.name} --force (coming soon)`,
+          },
+        );
+      }
+      break;
+
+    case "pending":
+    case "awaitingcapacity":
+      // Pending/awaiting nodes
+      if (lastVm?.id) {
+        nodeActions.push(
+          { label: "Logs", command: `sf vms logs ${lastVm.id}` },
+        );
+      }
+
+      if (node.node_type === "spot") {
+        // Spot nodes: can update, release, delete
+        nodeActions.push(
+          {
+            label: "Update",
+            command: `sf nodes set ${node.name} --max-price 12.50`,
+          },
+          { label: "Release", command: `sf nodes release ${node.name}` },
+          {
+            label: "Delete",
+            command: `sf nodes delete ${node.name} --force (coming soon)`,
+          },
+        );
+      } else if (node.node_type === "reserved") {
+        // Reserved nodes: can delete
+        nodeActions.push({
+          label: "Delete",
+          command: `sf nodes delete ${node.name} --force (coming soon)`,
+        });
+      }
+      break;
+
+    default:
+      // For unknown statuses, show basic actions if VM is available
+      if (lastVm?.id) {
+        nodeActions.push(
+          { label: "Logs", command: `sf vms logs ${lastVm.id}` },
+          { label: "SSH", command: `sf vms ssh ${lastVm.id}` },
+        );
+      }
+      nodeActions.push({
+        label: "Release",
+        command: `sf nodes release ${node.name}`,
+      });
+      break;
+  }
+  return nodeActions;
+}
 
 // Component for displaying a single node in verbose format
 function NodeVerboseDisplay({ node }: { node: SFCNodes.Node }) {
   // Convert Unix timestamps to dates and calculate duration
   const startDate = node.start_at && dayjs.unix(node.start_at);
   const endDate = node.end_at && dayjs.unix(node.end_at);
-  const duration = endDate && startDate && endDate.diff(startDate, "hours");
-
+  let duration = endDate && startDate && endDate.diff(startDate, "hours");
+  if (typeof duration === "number" && duration < 1) {
+    duration = 1;
+  }
   // Convert max_price_per_node_hour from cents to dollars
   const pricePerHour = node.max_price_per_node_hour
     ? (node.max_price_per_node_hour / 100)
@@ -33,6 +215,9 @@ function NodeVerboseDisplay({ node }: { node: SFCNodes.Node }) {
   const totalCost = duration && node.max_price_per_node_hour
     ? (duration * node.max_price_per_node_hour / 100)
     : 0;
+
+  // Get available actions for this node
+  const nodeActions = getActionsForNode(node);
 
   return (
     <Box
@@ -67,33 +252,33 @@ function NodeVerboseDisplay({ node }: { node: SFCNodes.Node }) {
       <Box marginTop={1} paddingX={1}>
         <Text>📅 Schedule:</Text>
       </Box>
-      {node.node_type === "spot" && (
-        <Box marginLeft={4}>
-          <Text color="yellow">
-            This node is spot and has no explicit start, end, or duration.
-          </Text>
-        </Box>
-      )}
-      {node.node_type !== "spot" && (
-        <Box marginLeft={3} flexDirection="column" paddingX={1}>
-          <Row
-            head="Start: "
-            value={startDate
-              ? `${startDate.format("YYYY-MM-DD HH:mm:ss")} UTC`
-              : "Not specified"}
-          />
-          <Row
-            head="End: "
-            value={endDate
-              ? `${endDate.format("YYYY-MM-DD HH:mm:ss")} UTC`
-              : "Not specified"}
-          />
+
+      <Box marginLeft={3} flexDirection="column" paddingX={1}>
+        <Row
+          head="Start: "
+          value={startDate
+            ? `${startDate.format("YYYY-MM-DD HH:mm:ss")} UTC`
+            : "Not specified"}
+        />
+        <Row
+          head={node.node_type === "spot" &&
+              (node.status === "running" ||
+                node.status === "pending" ||
+                node.status === "awaitingcapacity") &&
+              endDate
+            ? "End (Rolling): "
+            : "End: "}
+          value={endDate
+            ? `${endDate.format("YYYY-MM-DD HH:mm:ss")} UTC`
+            : "Not specified"}
+        />
+        {duration && (
           <Row
             head="Duration: "
-            value={duration ? `${duration} hours` : "Not specified"}
+            value={`${duration} hours`}
           />
-        </Box>
-      )}
+        )}
+      </Box>
 
       <Box marginTop={1} paddingX={1}>
         <Text>💰 Pricing:</Text>
@@ -119,20 +304,35 @@ function NodeVerboseDisplay({ node }: { node: SFCNodes.Node }) {
         )}
       </Box>
 
-      <Box marginTop={1} paddingX={1}>
-        <Text>🎯 Actions:</Text>
-      </Box>
-      <Box marginLeft={3} flexDirection="column" paddingX={1}>
-        <Row head="Logs: " value={`sf vms logs ${node.name}`} />
-        <Row head="SSH: " value={`sf vms ssh ${node.name}`} />
-        {node.node_type !== "spot" && (
-          <Row
-            head="Extend: "
-            value={`sf nodes extend ${node.name} --duration 60 --max-price 12.00`}
-          />
-        )}
-        <Row head="Release: " value={`sf nodes release ${node.name}`} />
-      </Box>
+      {/* VMs Section - Show if node has VMs */}
+      {node.vms?.data && node.vms.data.length > 0 && (
+        <Box flexDirection="row" gap={0}>
+          <Box marginTop={1} paddingX={1}>
+            <Text color="cyan" bold>💿</Text>
+          </Box>
+          <Box marginTop={1}>
+            <VMTable vms={node.vms.data} />
+          </Box>
+        </Box>
+      )}
+
+      {/* Actions Section - Show based on available actions */}
+      {nodeActions.length > 0 && (
+        <>
+          <Box marginTop={1} paddingX={1}>
+            <Text>🎯 Actions:</Text>
+          </Box>
+          <Box marginLeft={3} flexDirection="column" paddingX={1}>
+            {nodeActions.map((action, index) => (
+              <Row
+                key={index}
+                head={`${action.label}: `}
+                value={action.command}
+              />
+            ))}
+          </Box>
+        </>
+      )}
     </Box>
   );
 }
@@ -184,9 +384,55 @@ async function listNodesAction(options: ReturnType<typeof list.opts>) {
           }. Use --verbose for detailed information, such as previous virtual machines.`,
         ),
       );
-      console.log(gray("\nExamples:"));
-      console.log(`  sf nodes set ${nodes[0].name} --max-price 12.50`);
-      console.log(`  sf nodes release ${nodes[0].name}`);
+
+      // Get actions from all nodes, deduplicated with newest nodes taking precedence
+      const nodesCommands: string[] = [];
+      const vmsCommands: string[] = [];
+      const seenNodesLabels = new Set<string>();
+
+      // Sort nodes by created_at (newest first), fallback to index for consistent ordering
+      const sortedNodes = [...nodes].sort((a, b) => {
+        const aTime = a.created_at || 0;
+        const bTime = b.created_at || 0;
+        return bTime - aTime; // Newest first
+      });
+
+      // Collect actions from each node, with newer nodes taking precedence
+      // Limit to 3 nodes commands and 1 vms command
+      for (const node of sortedNodes) {
+        const nodeActions = getActionsForNode(node);
+        for (const action of nodeActions) {
+          const isVmsCommand = action.command.includes("sf vms");
+
+          if (isVmsCommand) {
+            // Only add the first vms command we encounter (from newest node)
+            if (vmsCommands.length === 0) {
+              vmsCommands.push(action.command);
+            }
+          } else {
+            // For nodes commands, limit to 3 and deduplicate by label
+            if (
+              nodesCommands.length < 3 && !seenNodesLabels.has(action.label)
+            ) {
+              nodesCommands.push(action.command);
+              seenNodesLabels.add(action.label);
+            }
+          }
+        }
+      }
+
+      // Print Next Steps section
+      if (nodesCommands.length > 0 || vmsCommands.length > 0) {
+        console.log(gray("\nNext steps:"));
+        // Print nodes commands first
+        for (const command of nodesCommands) {
+          console.log(`  ${command}`);
+        }
+        // Then print vms commands
+        for (const command of vmsCommands) {
+          console.log(`  ${command}`);
+        }
+      }
     }
   } catch (err) {
     handleNodesError(err);

--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -22,6 +22,10 @@ import {
 
 // Helper component to display VMs in a table format using Ink
 function VMTable({ vms }: { vms: NonNullable<SFCNodes.Node["vms"]>["data"] }) {
+  const sortedVms = vms.sort((a, b) => b.updated_at - a.updated_at);
+  const vmsToShow = sortedVms.slice(0, 5);
+  const remainingVms = sortedVms.length - 5;
+
   return (
     <Box flexDirection="column" padding={0}>
       {/* Header */}
@@ -47,7 +51,7 @@ function VMTable({ vms }: { vms: NonNullable<SFCNodes.Node["vms"]>["data"] }) {
       </Box>
 
       {/* VM rows */}
-      {vms.map((vm) => {
+      {vmsToShow.map((vm) => {
         const startDate = vm.start_at ? dayjs.unix(vm.start_at) : null;
         const endDate = vm.end_at ? dayjs.unix(vm.end_at) : null;
 
@@ -76,6 +80,18 @@ function VMTable({ vms }: { vms: NonNullable<SFCNodes.Node["vms"]>["data"] }) {
           </Box>
         );
       })}
+
+      {/* Show message if there are more VMs */}
+      {remainingVms > 0 && (
+        <Box gap={1}>
+          <Text color="gray">
+            {remainingVms} past {remainingVms === 1 ? "VM" : "VMs"} not shown.
+          </Text>
+          <Text color="cyan">
+            (To see all VMs, use `sf nodes ls --json`)
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -201,7 +201,7 @@ const list = new Command("list")
   .addHelpText(
     "after",
     `
-Examples:
+Next Steps:\n
   \x1b[2m# List nodes in short format (default)\x1b[0m
   $ sf nodes list
 

--- a/src/lib/nodes/release.ts
+++ b/src/lib/nodes/release.ts
@@ -7,7 +7,12 @@ import ora from "ora";
 import type { SFCNodes } from "@sfcompute/nodes-sdk-alpha";
 
 import { handleNodesError, nodesClient } from "../../nodesClient.ts";
-import { createNodesTable, forceOption, jsonOption } from "./utils.ts";
+import {
+  createNodesTable,
+  forceOption,
+  jsonOption,
+  pluralizeNodes,
+} from "./utils.ts";
 
 async function releaseNodesAction(
   nodeNames: string[],
@@ -47,7 +52,13 @@ async function releaseNodesAction(
 
       if (nodesToRelease.length > 0) {
         console.log(createNodesTable(nodesToRelease));
-        console.log(gray(`\nWould release ${nodesToRelease.length} node(s).`));
+        console.log(
+          gray(
+            `\nWould release ${nodesToRelease.length} ${
+              pluralizeNodes(nodesToRelease.length)
+            }.`,
+          ),
+        );
       }
 
       if (notFound.length > 0) {
@@ -85,8 +96,9 @@ async function releaseNodesAction(
       }
 
       const confirmed = await confirm({
-        message:
-          `Release ${nodesToRelease.length} node(s)? This action cannot be undone.`,
+        message: `Release ${nodesToRelease.length} ${
+          pluralizeNodes(nodesToRelease.length)
+        }? This action cannot be undone.`,
         default: false,
       });
       if (!confirmed) {
@@ -95,7 +107,11 @@ async function releaseNodesAction(
       }
     }
 
-    const releaseSpinner = ora(`Releasing ${nodesToRelease.length} node(s)...`)
+    const releaseSpinner = ora(
+      `Releasing ${nodesToRelease.length} ${
+        pluralizeNodes(nodesToRelease.length)
+      }...`,
+    )
       .start();
 
     const results: { name: string; status: string }[] = [];
@@ -113,7 +129,9 @@ async function releaseNodesAction(
     }
 
     if (results.length > 0) {
-      releaseSpinner.succeed(`Released ${results.length} node(s)`);
+      releaseSpinner.succeed(
+        `Released ${results.length} ${pluralizeNodes(results.length)}`,
+      );
     }
 
     if (errors.length > 0) {
@@ -121,7 +139,9 @@ async function releaseNodesAction(
         releaseSpinner.fail("Failed to release any nodes");
       } else {
         releaseSpinner.warn(
-          `Released ${results.length} node(s), but ${errors.length} failed`,
+          `Released ${results.length} ${
+            pluralizeNodes(results.length)
+          }, but ${errors.length} failed`,
         );
       }
       console.error(gray("\nFailed to release:"));
@@ -159,7 +179,7 @@ const release = new Command("release")
   .addHelpText(
     "after",
     `
-Examples:
+Examples:\n
   \x1b[2m# Release a single node by name\x1b[0m
   $ sf nodes release node-1
 

--- a/src/lib/nodes/set.ts
+++ b/src/lib/nodes/set.ts
@@ -5,7 +5,7 @@ import console from "node:console";
 import type { SFCNodes } from "@sfcompute/nodes-sdk-alpha";
 
 import { handleNodesError, nodesClient } from "../../nodesClient.ts";
-import { maxPriceOption } from "./utils.ts";
+import { maxPriceOption, pluralizeNodes } from "./utils.ts";
 import { updateProcurement } from "../scale/update.tsx";
 import { GPUS_PER_NODE } from "../constants.ts";
 
@@ -80,10 +80,16 @@ async function setNodesAction(
 
     // Conclude spinner based on results
     if (results.length > 0 && errors.length === 0) {
-      spinner.succeed(`Successfully updated ${results.length} node(s)`);
+      spinner.succeed(
+        `Successfully updated ${results.length} ${
+          pluralizeNodes(results.length)
+        }`,
+      );
     } else if (results.length > 0 && errors.length > 0) {
       spinner.warn(
-        `Updated ${results.length} node(s), but ${errors.length} failed`,
+        `Updated ${results.length} ${
+          pluralizeNodes(results.length)
+        }, but ${errors.length} failed`,
       );
     } else {
       spinner.fail("Failed to update any nodes");
@@ -133,7 +139,7 @@ const set = new Command("set")
   .addHelpText(
     "after",
     `
-Examples:
+Examples:\n
   \x1b[2m# Update max price for a single node\x1b[0m
   $ sf nodes set node-1 --max-price 15.00
 

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -230,7 +230,7 @@ export const zoneOption = new Option(
  */
 export const maxPriceOption = new Option(
   "-p, --max-price <price>",
-  "Maximum price per node per hour in dollars",
+  "Maximum price per node hour in dollars",
 ).argParser(validatePrice).makeOptionMandatory();
 
 /**

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -111,6 +111,17 @@ export function pluralizeNodes(count: number) {
 }
 
 /**
+ * Determine node type based on create command options
+ * @param options Options object with duration and/or end properties
+ * @returns "reserved" if duration or end is provided, "spot" otherwise
+ */
+export function determineNodeType(
+  options: { duration?: number; end?: Date },
+): "reserved" | "spot" {
+  return (options.duration || options.end) ? "reserved" : "spot";
+}
+
+/**
  * Validates that a price value is a positive number and meets a minimum threshold
  * @param val String value to validate
  * @param minimum Minimum allowed price (default: 0)

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -1,4 +1,11 @@
-import { cyan, gray, green, red, yellow } from "jsr:@std/fmt/colors";
+import {
+  brightBlack,
+  cyan,
+  gray,
+  green,
+  red,
+  yellow,
+} from "jsr:@std/fmt/colors";
 import type { SFCNodes } from "@sfcompute/nodes-sdk-alpha";
 import Table from "cli-table3";
 import dayjs from "dayjs";
@@ -40,6 +47,35 @@ export function getStatusColor(status: SFCNodes.Node["status"]): string {
   }
 }
 
+export function printVMStatus(status: string): string {
+  switch (status) {
+    case "NodeFailure":
+      return "Node Failure";
+    default:
+      if (status.length === 0) return "Unknown";
+      return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+}
+
+export function getVMStatusColor(status: string): string {
+  const statusText = printVMStatus(status);
+
+  switch (status) {
+    case "Pending":
+      return yellow(statusText);
+    case "Running":
+      return green(statusText);
+    case "Destroyed":
+      return brightBlack(statusText);
+    case "NodeFailure":
+      return red(statusText);
+    case "Unspecified":
+      return gray(statusText);
+    default:
+      return statusText;
+  }
+}
+
 export function printNodeType(nodeType: SFCNodes.Node["node_type"]) {
   switch (nodeType) {
     case "spot":
@@ -62,7 +98,7 @@ export function createNodesTable(nodes: SFCNodes.Node[]): string {
       cyan("NAME"),
       cyan("TYPE"),
       cyan("STATUS"),
-      cyan("CURRENT VIRTUAL MACHINE"),
+      cyan("CURRENT VM"),
       cyan("GPU"),
       cyan("ZONE"),
       cyan("START/END"),

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -62,6 +62,7 @@ export function createNodesTable(nodes: SFCNodes.Node[]): string {
       cyan("NAME"),
       cyan("TYPE"),
       cyan("STATUS"),
+      cyan("CURRENT VIRTUAL MACHINE"),
       cyan("GPU"),
       cyan("ZONE"),
       cyan("START/END"),
@@ -92,10 +93,14 @@ export function createNodesTable(nodes: SFCNodes.Node[]): string {
       ? (node.max_price_per_node_hour / 100).toFixed(2)
       : "N/A";
 
+    const lastVm = node.vms?.data.sort((a, b) => b.updated_at - a.updated_at)
+      .at(0);
+
     table.push([
       node.name,
       printNodeType(node.node_type),
       getStatusColor(node.status),
+      lastVm?.id ?? "",
       node.gpu_type,
       node.zone || "N/A",
       startEnd,

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -106,6 +106,10 @@ export function createNodesTable(nodes: SFCNodes.Node[]): string {
   return table.toString();
 }
 
+export function pluralizeNodes(count: number) {
+  return count === 1 ? "node" as const : "nodes" as const;
+}
+
 /**
  * Validates that a price value is a positive number and meets a minimum threshold
  * @param val String value to validate


### PR DESCRIPTION
## Educate the user on the relationship between virtual machines and nodes
<img width="2666" height="558" alt="image" src="https://github.com/user-attachments/assets/cea81381-e432-43c6-91f0-10958adba01f" />

<img width="1644" height="1188" alt="image" src="https://github.com/user-attachments/assets/009a7d03-4b26-4abc-b810-fc4317c2fd06" />

<img width="1572" height="412" alt="image" src="https://github.com/user-attachments/assets/748a48fa-009d-4afd-8b21-553e9b25f816" />

## Enhanced validation in sf nodes extend - The command now pre-validates nodes, prevents extending spot nodes (which auto-extend), and provides clear error messages
<img width="2480" height="1020" alt="image" src="https://github.com/user-attachments/assets/79f84433-f06c-40d1-9b1b-4832b8663677" />

## Improved user experience - Consistent grammar with proper singular/plural forms, better formatting, and more helpful error messages
- Context-aware recommendations - Different command suggestions based on node type (spot nodes get sf nodes set suggestions instead of sf nodes extend)
<img width="2656" height="850" alt="image" src="https://github.com/user-attachments/assets/5e688e74-43ba-49a5-9231-16527838728d" />
