### PR TITLE
chore: Add user to sf vms ssh command examples

### DIFF
--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -114,7 +114,7 @@ function getActionsForNode(node: SFCNodes.Node) {
         );
         nodeActions.push({
           label: "SSH",
-          command: `sf vms ssh ${lastVm.id}`,
+          command: `sf vms ssh root@${lastVm.id}`,
         });
       }
       nodeActions.push({
@@ -134,7 +134,7 @@ function getActionsForNode(node: SFCNodes.Node) {
       if (lastVm?.id) {
         nodeActions.push(
           { label: "Logs", command: `sf vms logs ${lastVm.id}` },
-          { label: "SSH", command: `sf vms ssh ${lastVm.id}` },
+          { label: "SSH", command: `sf vms ssh root@${lastVm.id}` },
         );
       }
 
@@ -203,7 +203,7 @@ function getActionsForNode(node: SFCNodes.Node) {
       if (lastVm?.id) {
         nodeActions.push(
           { label: "Logs", command: `sf vms logs ${lastVm.id}` },
-          { label: "SSH", command: `sf vms ssh ${lastVm.id}` },
+          { label: "SSH", command: `sf vms ssh root@${lastVm.id}` },
         );
       }
       nodeActions.push({


### PR DESCRIPTION
Add `root@` prefix to `sf vms ssh` commands to ensure successful SSH connections.

The `sf vms ssh` command requires a user prefix (e.g., `root@`) to function correctly, as confirmed by user testing in the provided Slack thread. This change ensures the command works as expected for users.

---
[Slack Thread](https://sfcompute.slack.com/archives/C080PSH54JZ/p1754551985079199?thread_ts=1754551985.079199&cid=C080PSH54JZ)

<a href="https://cursor.com/background-agent?bcId=bc-de65a662-f600-449d-bb1f-230bbc2d1155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de65a662-f600-449d-bb1f-230bbc2d1155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>