### PR TITLE
chore: enable error help text and add -p flag to examples

### DIFF
--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -122,19 +122,19 @@ Examples:\n
   $ sf nodes create node-1 --zone hayesvalley --max-price 12.50
 
   \x1b[2m# Create multiple nodes with specific names\x1b[0m
-  $ sf nodes create node-1 node-2 node-3 --zone hayesvalley --max-price 9
+  $ sf nodes create node-1 node-2 node-3 --zone hayesvalley --max-price 9.00
 
   \x1b[2m# Create 3 nodes with auto-generated names\x1b[0m
   $ sf nodes create -n 3 --zone hayesvalley --max-price 10.00
 
   \x1b[2m# Create a reserved node with specific start/end times\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --start "2024-01-15T10:00:00Z" --end "2024-01-15T12:00:00Z"
+  $ sf nodes create node-1 --zone hayesvalley --start "2024-01-15T10:00:00Z" --end "2024-01-15T12:00:00Z" -p 15.00
 
   \x1b[2m# Create a reserved node for 2 hours starting now\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --duration 2h
+  $ sf nodes create node-1 --zone hayesvalley --duration 2h -p 13.50
 
   \x1b[2m# Create a reserved node starting in 1 hour for 6 hours\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --start "+1h" --duration 6h
+  $ sf nodes create node-1 --zone hayesvalley --start "+1h" --duration 6h -p 11.25
 `,
   )
   .action(createNodesAction);

--- a/src/lib/nodes/extend.ts
+++ b/src/lib/nodes/extend.ts
@@ -20,6 +20,7 @@ import { logAndQuit } from "../../helpers/errors.ts";
 
 const extend = new Command("extend")
   .description("Extend the duration of reserved nodes and update their pricing")
+  .showHelpAfterError()
   .argument("<nodes...>", "Node IDs or names to extend")
   .addOption(requiredDurationOption)
   .addOption(maxPriceOption)

--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -458,6 +458,7 @@ async function listNodesAction(options: ReturnType<typeof list.opts>) {
 const list = new Command("list")
   .alias("ls")
   .description("List all compute nodes")
+  .showHelpAfterError()
   .option("--verbose", "Show detailed information for each node")
   .addOption(jsonOption)
   .addHelpText(

--- a/src/lib/nodes/release.ts
+++ b/src/lib/nodes/release.ts
@@ -18,6 +18,7 @@ const release = new Command("release")
   .description(
     "Release one or more compute nodes (stop a node from auto-renewing)",
   )
+  .showHelpAfterError()
   .argument("<names...>", "Node IDs or names to release")
   .addOption(forceOption)
   .option(

--- a/src/lib/nodes/set.ts
+++ b/src/lib/nodes/set.ts
@@ -134,6 +134,7 @@ async function setNodesAction(
 
 const set = new Command("set")
   .description("Update attributes of one or more compute nodes")
+  .showHelpAfterError()
   .argument("<names...>", "Names of the nodes to update")
   .addOption(maxPriceOption)
   .addHelpText(


### PR DESCRIPTION
Enable help text on error for `sf nodes` subcommands and add required `--max-price` flag to `sf create` examples.

---
[Slack Thread](https://sfcompute.slack.com/archives/C080PSH54JZ/p1754689645766149?thread_ts=1754689645.766149&cid=C080PSH54JZ)

<a href="https://cursor.com/background-agent?bcId=bc-c0cd580f-a46f-4e32-9d15-a3f3044e110b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0cd580f-a46f-4e32-9d15-a3f3044e110b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

