### PR TITLE
feat: [ENG-2165] add --reserved and --auto flags to sf nodes create

### DIFF
--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -1,4 +1,4 @@
-import { Command, CommanderError } from "@commander-js/extra-typings";
+import { Command, CommanderError, Option } from "@commander-js/extra-typings";
 import { confirm } from "@inquirer/prompts";
 import { cyan, gray, red, yellow } from "jsr:@std/fmt/colors";
 import console from "node:console";
@@ -8,7 +8,6 @@ import type { SFCNodes } from "@sfcompute/nodes-sdk-alpha";
 
 import {
   createNodesTable,
-  determineNodeType,
   durationOption,
   endOption,
   jsonOption,
@@ -74,6 +73,18 @@ const create = new Command("create")
   )
   .addOption(zoneOption)
   .addOption(maxPriceOption)
+  .addOption(
+    new Option(
+      "--reserved",
+      "Create reserved nodes. Reserved nodes have an explicit start and end time.",
+    ).conflicts("auto"),
+  )
+  .addOption(
+    new Option(
+      "--auto",
+      "Create auto-reserved nodes. Auto-reserved nodes self-extend until they are released.",
+    ).conflicts("reserved"),
+  )
   .addOption(startOption)
   .addOption(endOption.conflicts("duration"))
   .addOption(durationOption.conflicts("end"))
@@ -81,7 +92,8 @@ const create = new Command("create")
   .addOption(jsonOption)
   .hook("preAction", (command) => {
     const names = command.args;
-    const { count, duration, end, zone } = command.opts();
+    const { count, start, duration, end, auto, reserved } = command
+      .opts();
 
     // Validate arguments
     if (names.length === 0 && !count) {
@@ -104,17 +116,41 @@ const create = new Command("create")
       }
     }
 
+    if (reserved && auto) {
+      console.error(red("Specify either --reserved or --auto, but not both\n"));
+      command.help();
+      process.exit(1);
+    }
+
     // Validate duration/end like buy command
-    if (end && duration) {
+    if (typeof end !== "undefined" && typeof duration !== "undefined") {
       console.error(red("Specify either --duration or --end, but not both\n"));
       command.help();
       process.exit(1);
     }
 
-    const isReserved = !!(duration || end);
-    if (!isReserved && !zone) {
+    // Validate that timing flags are only used with reserved nodes
+    if (
+      auto &&
+      (typeof start !== "undefined" || typeof duration !== "undefined" ||
+        typeof end !== "undefined")
+    ) {
       console.error(
-        red("Must specify --zone when creating auto reserved nodes\n"),
+        red(
+          "Auto-reserved nodes start immediately and cannot have a start time, duration, or end time.\n",
+        ),
+      );
+      command.help();
+      process.exit(1);
+    }
+
+    if (
+      !auto && typeof duration === "undefined" && typeof end === "undefined"
+    ) {
+      console.error(
+        red(
+          "You must specify either --duration or --end to create a reserved node.\n",
+        ),
       );
       command.help();
       process.exit(1);
@@ -124,23 +160,23 @@ const create = new Command("create")
     "after",
     `
 Examples:\n
-  \x1b[2m# Create a single node with a specific name\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --max-price 12.50
+  \x1b[2m# Create a single reserved node (default behavior)\x1b[0m
+  $ sf nodes create --zone hayesvalley --max-price 12.50
 
-  \x1b[2m# Create multiple nodes with specific names\x1b[0m
-  $ sf nodes create node-1 node-2 node-3 --zone hayesvalley --max-price 9.00
+  \x1b[2m# Create multiple auto-reserved nodes explicitly with a specific name\x1b[0m
+  $ sf nodes create node-1 node-2 node-3 --zone hayesvalley --auto --max-price 9.00
 
-  \x1b[2m# Create 3 nodes with auto-generated names\x1b[0m
-  $ sf nodes create -n 3 --zone hayesvalley --max-price 10.00
+  \x1b[2m# Create 3 auto-reserved nodes with auto-generated names\x1b[0m
+  $ sf nodes create -n 3 --zone hayesvalley --auto --max-price 10.00
 
   \x1b[2m# Create a reserved node with specific start/end times\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --start "2024-01-15T10:00:00Z" --end "2024-01-15T12:00:00Z" -p 15.00
+  $ sf nodes create node-1 --zone hayesvalley --reserved --start "2024-01-15T10:00:00Z" --end "2024-01-15T12:00:00Z" -p 15.00
 
   \x1b[2m# Create a reserved node for 2 hours starting now\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --duration 2h -p 13.50
+  $ sf nodes create node-1 --zone hayesvalley --reserved --duration 2h -p 13.50
 
   \x1b[2m# Create a reserved node starting in 1 hour for 6 hours\x1b[0m
-  $ sf nodes create node-1 --zone hayesvalley --start "+1h" --duration 6h -p 11.25
+  $ sf nodes create node-1 --zone hayesvalley --reserved --start "+1h" --duration 6h -p 11.25
 `,
   )
   .action(createNodesAction);
@@ -152,8 +188,12 @@ async function createNodesAction(
   try {
     const client = await nodesClient();
     const count = options.count ?? names.length;
-    const nodeType = determineNodeType(options);
-    const isReserved = nodeType === "reserved";
+    // Because we validate that --reserved and --auto are mutually exclusive,
+    // we can use the presence of --auto to determine if the nodes are auto-reserved.
+    const isReserved = !options.auto;
+    const nodeType = options.auto
+      ? "autoreserved" as const
+      : "reserved" as const;
 
     // Only show pricing and get confirmation if not using --yes
     if (!options.yes) {

--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -132,7 +132,7 @@ const create = new Command("create")
     // Validate that timing flags are only used with reserved nodes
     if (
       auto &&
-      (typeof start !== "undefined" || typeof duration !== "undefined" ||
+      (start !== "NOW" || typeof duration !== "undefined" ||
         typeof end !== "undefined")
     ) {
       console.error(

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -152,17 +152,6 @@ export function pluralizeNodes(count: number) {
 }
 
 /**
- * Determine node type based on create command options
- * @param options Options object with duration and/or end properties
- * @returns "reserved" if duration or end is provided, "autoreserved" otherwise
- */
-export function determineNodeType(
-  options: { duration?: number; end?: Date },
-): "reserved" | "autoreserved" {
-  return (options.duration || options.end) ? "reserved" : "autoreserved";
-}
-
-/**
  * Validates that a price value is a positive number and meets a minimum threshold
  * @param val String value to validate
  * @param minimum Minimum allowed price (default: 0)

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -290,8 +290,8 @@ export const maxPriceOption = new Option(
  */
 export const startOption = new Option(
   "-s, --start <start>",
-  "Start time (ISO 8601 format or relative time like '+1d', or 'now')",
-).argParser(parseStartDate).default("now");
+  "Start time (ISO 8601 format or relative time like '+1d', or 'NOW')",
+).argParser(parseStartDate).default("NOW");
 
 /**
  * Common --end option using same parser as buy command


### PR DESCRIPTION
> The CLI should delineate clearly between these two types of Nodes Auto-Reserved vs Reservation.
> 
> Folks using auto nodes should understand that we will continue to buy time on their behalf and spin nodes up and down.
> 
> Additionally, when using auto nodes users should be ok with their vm being interrupted.
> 
> I think we want to drill into users heads that these are two separate concepts for different use cases