### PR TITLE
fix(buy): fix bug in rate display logic

### DIFF
--- a/src/helpers/units.ts
+++ b/src/helpers/units.ts
@@ -42,6 +42,13 @@ export function roundEndDate(endDate: Date): Date {
   return epochToDate(roundEpochUpToHour(dateToEpoch(endDate)));
 }
 
+export function roundDateUpToNextMinute(date: Date): Date {
+  const d = dayjs(date);
+  return d.second() === 0 && d.millisecond() === 0
+    ? d.toDate()
+    : d.add(1, "minute").startOf("minute").toDate();
+}
+
 function dateToEpoch(date: Date): number {
   return Math.ceil(date.getTime() / MILLS_PER_EPOCH);
 }

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -33,7 +33,6 @@ import { Row } from "../Row.tsx";
 import { GPUS_PER_NODE } from "../constants.ts";
 import { parseAccelerators } from "../index.ts";
 import { analytics } from "../posthog.ts";
-import { Dayjs } from "dayjs";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -734,7 +733,6 @@ export async function placeBuyOrder(options: {
   return data;
 }
 
-
 function roundDateUpToNextMinute(date: Date) {
   const d = dayjs(date);
   return d.second() === 0 && d.millisecond() === 0
@@ -747,7 +745,9 @@ export function getPricePerGpuHourFromQuote(quote: NonNullable<Quote>) {
   // from the market's perspective, "NOW" means at the beginning of the next minute.
   // when the order duration is very short, this can cause the rate to be computed incorrectly
   // if we implicitly assume it to mean `new Date()`.
-  const coercedStartTime = startTimeOrNow === "NOW" ? roundDateUpToNextMinute(new Date()) : startTimeOrNow;
+  const coercedStartTime = startTimeOrNow === "NOW"
+    ? roundDateUpToNextMinute(new Date())
+    : startTimeOrNow;
   const durationSeconds = dayjs(quote.end_at).diff(dayjs(coercedStartTime));
   const durationHours = durationSeconds / 3600 / 1000;
 

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -33,6 +33,7 @@ import { Row } from "../Row.tsx";
 import { GPUS_PER_NODE } from "../constants.ts";
 import { parseAccelerators } from "../index.ts";
 import { analytics } from "../posthog.ts";
+import { Dayjs } from "dayjs";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -733,10 +734,21 @@ export async function placeBuyOrder(options: {
   return data;
 }
 
+
+function roundDateUpToNextMinute(date: Date) {
+  const d = dayjs(date);
+  return d.second() === 0 && d.millisecond() === 0
+    ? d
+    : d.add(1, "minute").startOf("minute");
+}
 export function getPricePerGpuHourFromQuote(quote: NonNullable<Quote>) {
-  const durationSeconds = dayjs(quote.end_at).diff(
-    parseStartDate(quote.start_at),
-  );
+  const startTimeOrNow = parseStartDateOrNow(quote.start_at);
+
+  // from the market's perspective, "NOW" means at the beginning of the next minute.
+  // when the order duration is very short, this can cause the rate to be computed incorrectly
+  // if we implicitly assume it to mean `new Date()`.
+  const coercedStartTime = startTimeOrNow === "NOW" ? roundDateUpToNextMinute(new Date()) : startTimeOrNow;
+  const durationSeconds = dayjs(quote.end_at).diff(dayjs(coercedStartTime));
   const durationHours = durationSeconds / 3600 / 1000;
 
   return quote.price / GPUS_PER_NODE / quote.quantity / durationHours;

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -23,6 +23,7 @@ import {
   centsToDollarsFormatted,
   parseStartDate,
   parseStartDateOrNow,
+  roundDateUpToNextMinute,
   roundEndDate,
   roundStartDate,
 } from "../../helpers/units.ts";
@@ -733,12 +734,6 @@ export async function placeBuyOrder(options: {
   return data;
 }
 
-function roundDateUpToNextMinute(date: Date) {
-  const d = dayjs(date);
-  return d.second() === 0 && d.millisecond() === 0
-    ? d
-    : d.add(1, "minute").startOf("minute");
-}
 export function getPricePerGpuHourFromQuote(quote: NonNullable<Quote>) {
   const startTimeOrNow = parseStartDateOrNow(quote.start_at);
 


### PR DESCRIPTION
Edge case: when the order's duration is very short, the displayed rate is wrong. The reason why it's wrong is that the market treats the string `"NOW"` as "the beginning of the next minute", not `new Date()`. 

This PR fixes it by handling this explicitly in `getPricePerGpuHourFromQuote`

```
sf buy -d 1m -t h200ki
Automatically upgrading 0.19.12 → 0.19.13
✔ Downloading install script
✔ Upgrade completed successfully

☁️☁️☁️

start  aug 27 5:55 pm (now)
end    aug 27 6:00 pm (in 5 minutes)
dur    ~5m
size   8 gpus
type   Kubernetes (h200ki)
rate   ~$1.86/gpu/hr
total  $1.12

Place order? (y/n)  
sf buy -d 1h -t h200ki
start  aug 27 5:55 pm (now)
end    aug 27 7:00 pm (in an hour)
dur    ~1h
size   8 gpus
type   Kubernetes (h200ki)
rate   ~$2.10/gpu/hr
total  $17.92

Place order? (y/n)  
```