### PR TITLE
feat: [ENG-2209] use `little-date` and `date-fns` to format nodes/vm start end times

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -18,6 +18,7 @@
     "npm:chrono-node@^2.7.6": "2.8.4",
     "npm:cli-table3@0.6.5": "0.6.5",
     "npm:commander@^12.1.0": "12.1.0",
+    "npm:date-fns@^4.1.0": "4.1.0",
     "npm:dayjs@*": "1.11.13",
     "npm:dayjs@1.11.13": "1.11.13",
     "npm:dayjs@^1.11.13": "1.11.13",
@@ -428,6 +429,9 @@
         "@babel/runtime"
       ]
     },
+    "date-fns@4.1.0": {
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+    },
     "dayjs@1.11.13": {
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
@@ -708,7 +712,7 @@
     "little-date@1.0.0": {
       "integrity": "sha512-41T/ktcwPzxC0OJ8E3wmaK0E1DL/QNR3n30kB9Dw6Ni6Eud24It8LZm70jK8lvDd+Mg+961fzKDcF6SQRL25cQ==",
       "dependencies": [
-        "date-fns"
+        "date-fns@2.30.0"
       ]
     },
     "log-symbols@6.0.0": {
@@ -1196,6 +1200,7 @@
         "npm:chrono-node@^2.7.6",
         "npm:cli-table3@0.6.5",
         "npm:commander@^12.1.0",
+        "npm:date-fns@^4.1.0",
         "npm:dayjs@^1.11.13",
         "npm:dotenv@^16.4.5",
         "npm:ink-confirm-input@2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "chrono-node": "^2.7.6",
     "cli-table3": "0.6.5",
     "commander": "^12.1.0",
+    "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "ink": "^5.2.0",

--- a/src/helpers/format-date.ts
+++ b/src/helpers/format-date.ts
@@ -1,0 +1,86 @@
+import {
+  format,
+  isSameDay,
+  isSameMinute,
+  isSameYear,
+  startOfDay,
+} from "date-fns";
+import { formatDateRange } from "little-date";
+import type { Dayjs } from "dayjs";
+
+const shortenAmPm = (text: string): string => {
+  const shortened = (text || "").replace(/ AM/g, "am").replace(/ PM/g, "pm");
+  const withoutDoubleZero = shortened.includes("m")
+    ? shortened.replace(/:00/g, "")
+    : shortened;
+  return withoutDoubleZero;
+};
+
+const removeLeadingZero = (text: string): string => text.replace(/^0/, "");
+
+const formatTime = (date: Date, locale?: string): string => {
+  return removeLeadingZero(
+    shortenAmPm(
+      date.toLocaleTimeString(locale, {
+        hour: "2-digit",
+        minute: "2-digit",
+      }) || "",
+    ),
+  );
+};
+
+const createFormatTime = (locale?: string) => (date: Date): string =>
+  formatTime(date, locale);
+
+export const formatDate = (date: Date): string => {
+  const today = new Date();
+  const thisYear = isSameYear(date, today);
+  const thisDay = isSameDay(date, today);
+  const formatTimeWithLocale = createFormatTime("en-US");
+
+  const timeSuffix = !isSameMinute(startOfDay(date), date)
+    ? `, ${formatTimeWithLocale(date)}`
+    : "";
+
+  const yearSuffix = thisYear ? "" : `, ${format(date, "yyyy")}`;
+
+  // If it's today and we have time, just show the time
+  if (thisDay && timeSuffix) {
+    return `${formatTimeWithLocale(date)}`;
+  }
+
+  // Standard date format
+  return `${format(date, "LLL d")}${timeSuffix}${yearSuffix}`;
+};
+
+export const formatNullableDateRange = (
+  startDate: Dayjs | null | undefined,
+  endDate: Dayjs | null | undefined,
+): string => {
+  let startEnd = "";
+  if (startDate && endDate) {
+    startEnd = formatDateRange(startDate.toDate(), endDate.toDate(), {
+      includeTime: true,
+      separator: "→",
+    });
+    if (startEnd.includes("'")) {
+      startEnd = formatDateRange(startDate.toDate(), endDate.toDate(), {
+        includeTime: false,
+        separator: "→",
+      });
+    }
+  } else if (startDate) {
+    startEnd = `${formatDate(startDate.toDate())} → ?`;
+  } else {
+    startEnd = "Not available";
+  }
+
+  if (startDate) {
+    const thisDay = isSameDay(startDate.toDate(), new Date());
+    if (thisDay) {
+      startEnd = `Today, ${startEnd}`;
+    }
+  }
+
+  return startEnd;
+};

--- a/src/lib/nodes/list.tsx
+++ b/src/lib/nodes/list.tsx
@@ -9,6 +9,7 @@ import type { SFCNodes } from "@sfcompute/nodes-sdk-alpha";
 
 import { getAuthToken } from "../../helpers/config.ts";
 import { logAndQuit } from "../../helpers/errors.ts";
+import { formatNullableDateRange } from "../../helpers/format-date.ts";
 import { handleNodesError, nodesClient } from "../../nodesClient.ts";
 import { Row } from "../Row.tsx";
 import {
@@ -54,17 +55,7 @@ function VMTable({ vms }: { vms: NonNullable<SFCNodes.Node["vms"]>["data"] }) {
       {vmsToShow.map((vm) => {
         const startDate = vm.start_at ? dayjs.unix(vm.start_at) : null;
         const endDate = vm.end_at ? dayjs.unix(vm.end_at) : null;
-
-        let startEnd: string;
-        if (startDate && endDate) {
-          startEnd = `${startDate.format("YYYY-MM-DD HH:mm")} → ${
-            endDate.format("HH:mm")
-          }`;
-        } else if (startDate) {
-          startEnd = `${startDate.format("YYYY-MM-DD HH:mm")} → ?`;
-        } else {
-          startEnd = "Not available";
-        }
+        const startEnd = formatNullableDateRange(startDate, endDate);
 
         return (
           <Box key={vm.id}>

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -14,6 +14,7 @@ import { parseDate } from "chrono-node";
 import { parseDurationArgument } from "../../helpers/duration.ts";
 import { parseStartDate, roundEndDate } from "../../helpers/units.ts";
 import { logAndQuit } from "../../helpers/errors.ts";
+import { formatNullableDateRange } from "../../helpers/format-date.ts";
 
 export function printNodeStatus(status: SFCNodes.Node["status"]): string {
   switch (status) {
@@ -114,16 +115,7 @@ export function createNodesTable(nodes: SFCNodes.Node[]): string {
     const startDate = node.start_at ? dayjs.unix(node.start_at) : null;
     const endDate = node.end_at ? dayjs.unix(node.end_at) : null;
 
-    let startEnd: string;
-    if (startDate && endDate) {
-      startEnd = `${startDate.format("YYYY-MM-DD HH:mm")} → ${
-        endDate.format("HH:mm")
-      }`;
-    } else if (startDate) {
-      startEnd = `${startDate.format("YYYY-MM-DD HH:mm")} → ?`;
-    } else {
-      startEnd = "Not available";
-    }
+    const startEnd = formatNullableDateRange(startDate, endDate);
 
     const maxPrice = node.max_price_per_node_hour
       ? (node.max_price_per_node_hour / 100).toFixed(2)


### PR DESCRIPTION
Examples:

<img width="1458" height="670" alt="image" src="https://github.com/user-attachments/assets/6f6d4c23-e333-4e2f-8b19-ef21480baf16" />

<img width="315" height="122" alt="Screenshot 2025-08-27 at 6 40 07 PM" src="https://github.com/user-attachments/assets/6d76219f-647c-483b-b5eb-a8215fb7a4be" />