### PR TITLE
fix: fix race condition in poll loop

### DIFF
--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -433,7 +433,7 @@ function BuyOrder(props: BuyOrderProps) {
   const [isLoading, setIsLoading] = useState(false);
   const { exit } = useApp();
   const [order, setOrder] = useState<Order | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
   const [loadingMsg, setLoadingMsg] = useState<string | null>(
     "Placing order...",
   );
@@ -521,37 +521,28 @@ function BuyOrder(props: BuyOrderProps) {
   );
 
   useEffect(() => {
-    if (isLoading && intervalRef.current == null) {
-      intervalRef.current = setInterval(async () => {
-        if (!order) {
-          return;
-        }
-
-        const o = await getOrder(order.id);
-        if (!o) {
-          setLoadingMsg(
-            "Can't find order. This could be a network issue, try ctrl-c and running 'sf orders ls' to see if it was placed.",
-          );
-          return;
-        }
-        setOrder(o);
-
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
-        exit();
-        return;
-      }, 200);
+    if (!isLoading || !order?.id) {
+      return;
     }
 
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
+    const pollForOrder = async () => {
+      const o = await getOrder(order.id);
+      if (!o) {
+        setLoadingMsg(
+          "Can't find order. This could be a network issue, try ctrl-c and running 'sf orders ls' to see if it was placed.",
+        );
+        // Schedule next poll
+        setTimeout(pollForOrder, 200);
+        return;
       }
+      setOrder(o);
+      // Success - don't schedule another poll, we're done
+      exit();
     };
-  }, [isLoading, order, exit]);
+
+    // Start the first poll
+    setTimeout(pollForOrder, 200);
+  }, [isLoading, order?.id, exit]);
 
   useEffect(() => {
     if (!isLoading && props.yes) {

--- a/src/lib/buy/index.tsx
+++ b/src/lib/buy/index.tsx
@@ -6,12 +6,12 @@ import Spinner from "ink-spinner";
 import ms from "ms";
 import console from "node:console";
 import process from "node:process";
-import { clearInterval, setInterval, setTimeout } from "node:timers";
+import { setTimeout } from "node:timers";
 import dayjs from "npm:dayjs@1.11.13";
 import duration from "npm:dayjs@1.11.13/plugin/duration.js";
 import relativeTime from "npm:dayjs@1.11.13/plugin/relativeTime.js";
 import parseDurationFromLibrary from "parse-duration";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import invariant from "tiny-invariant";
 import { apiClient } from "../../apiClient.ts";
 import {


### PR DESCRIPTION
Sometimes `sf buy` re-enters its poll loop after the order is already filled. If `GET /v0/orders` fails when that occurs, `sf buy` will error out, even though the order successfully filled.

This PR attempts to fix this by doing two things:
1. Use a recursive `setTimeout` instead of a `setInterval`. That way, there will only ever be one poll happening at a time, which prevents redundant polls (the call to `exit()` will happen before the `useEffect` is re-run) 
2. use `order?.id` as the dependency to the `useEffect`, not `order`. This will prevent the `useEffect` from being run after calling `setOrder(o)`, because the order ID will be the same.