### PR TITLE
feat: enhance vm image url expiry date display

### DIFF
--- a/src/lib/vm/image/show.tsx
+++ b/src/lib/vm/image/show.tsx
@@ -70,11 +70,11 @@ export function ImageDisplay(
             value={
               <Box gap={1}>
                 <Text color={isExpired ? "red" : undefined}>
-                  {expiresAt.toISOString()} {
-                    brightBlack(
-                      `(${formatDate(dayjs(expiresAt).toDate())} ${dayjs(expiresAt).format("z")})`,
-                    )
-                  }
+                  {expiresAt.toISOString()} {brightBlack(
+                    `(${formatDate(dayjs(expiresAt).toDate())} ${
+                      dayjs(expiresAt).format("z")
+                    })`,
+                  )}
                 </Text>
                 {isExpired && <Text dimColor>(Expired)</Text>}
               </Box>


### PR DESCRIPTION
Display human-readable date alongside ISO string for "URL Expiry" in `sf vms images list` to match `sf nodes list --verbose`.

---
[Slack Thread](https://sfcompute.slack.com/archives/C082SQYP1H7/p1758041817414889?thread_ts=1758041817.414889&cid=C082SQYP1H7)

<a href="https://cursor.com/background-agent?bcId=bc-a8b645f5-8f18-4376-874f-8a0cb6d046d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8b645f5-8f18-4376-874f-8a0cb6d046d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

