### PR TITLE
Update vm image url expiry date display

### DIFF
--- a/src/lib/vm/image/show.tsx
+++ b/src/lib/vm/image/show.tsx
@@ -70,7 +70,7 @@ export function ImageDisplay(
             value={
               <Box gap={1}>
                 <Text color={isExpired ? "red" : undefined}>
-                  {dayjs(expiresAt).format("YYYY-MM-DDTHH:mm:ssZ")} {
+                  {expiresAt.toISOString()} {
                     brightBlack(
                       `(${formatDate(dayjs(expiresAt).toDate())} ${dayjs(expiresAt).format("z")})`,
                     )

--- a/src/lib/vm/image/show.tsx
+++ b/src/lib/vm/image/show.tsx
@@ -4,8 +4,18 @@ import { Command } from "@commander-js/extra-typings";
 import { Box, render, Text } from "ink";
 import Link from "ink-link";
 import console from "node:console";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import advanced from "dayjs/plugin/advancedFormat";
+import timezone from "dayjs/plugin/timezone";
+import { brightBlack } from "jsr:@std/fmt/colors";
 import { handleNodesError, nodesClient } from "../../../nodesClient.ts";
 import { Row } from "../../Row.tsx";
+import { formatDate } from "../../../helpers/format-date.ts";
+
+dayjs.extend(utc);
+dayjs.extend(advanced);
+dayjs.extend(timezone);
 
 export function ImageDisplay(
   { image }: {
@@ -60,7 +70,11 @@ export function ImageDisplay(
             value={
               <Box gap={1}>
                 <Text color={isExpired ? "red" : undefined}>
-                  {expiresAt.toISOString()}
+                  {dayjs(expiresAt).format("YYYY-MM-DDTHH:mm:ssZ")} {
+                    brightBlack(
+                      `(${formatDate(dayjs(expiresAt).toDate())} ${dayjs(expiresAt).format("z")})`,
+                    )
+                  }
                 </Text>
                 {isExpired && <Text dimColor>(Expired)</Text>}
               </Box>

--- a/src/lib/vm/image/show.tsx
+++ b/src/lib/vm/image/show.tsx
@@ -70,11 +70,11 @@ export function ImageDisplay(
             value={
               <Box gap={1}>
                 <Text color={isExpired ? "red" : undefined}>
-                  {expiresAt.toISOString()} {
-                    brightBlack(
-                      `(${formatDate(dayjs(expiresAt).toDate())} ${dayjs(expiresAt).format("z")})`,
-                    )
-                  }
+                  {expiresAt.toISOString()} {brightBlack(
+                    `(${formatDate(dayjs(expiresAt).toDate())} ${
+                      dayjs(expiresAt).format("z")
+                    })`,
+                  )}
                 </Text>
                 {isExpired && <Text dimColor>(Expired)</Text>}
               </Box>


### PR DESCRIPTION
Add human-readable date in bright black to `sf vms images list` URL Expiry, aligning its display with `sf nodes list --verbose`.

---
[Slack Thread](https://sfcompute.slack.com/archives/C082SQYP1H7/p1758041817414889?thread_ts=1758041817.414889&cid=C082SQYP1H7)

<a href="https://cursor.com/background-agent?bcId=bc-a8b645f5-8f18-4376-874f-8a0cb6d046d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8b645f5-8f18-4376-874f-8a0cb6d046d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

