### PR TITLE
Remove nodes api feature flag checks

### DIFF
--- a/src/lib/nodes/index.ts
+++ b/src/lib/nodes/index.ts
@@ -6,11 +6,8 @@ import release from "./release.ts";
 import set from "./set.ts";
 import extend from "./extend.ts";
 import get from "./get.tsx";
-import { isFeatureEnabled } from "../posthog.ts";
 
 export async function registerNodes(program: Command) {
-  const isEnabled = await isFeatureEnabled("vm-provider");
-  if (!isEnabled) return;
 
   const nodes = program
     .command("nodes")

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -72,7 +72,6 @@ const trackEvent = ({
 type FeatureFlags =
   | "procurements"
   | "zones"
-  | "vm-provider"
   | "custom-vm-images";
 
 /**


### PR DESCRIPTION
Remove the "vm-provider" feature flag checks because the nodes API is now in open beta and the flag was causing flakiness.

---
[Slack Thread](https://sfcompute.slack.com/archives/C080PSH54JZ/p1758159198688059?thread_ts=1758159198.688059&cid=C080PSH54JZ)

<a href="https://cursor.com/background-agent?bcId=bc-4e362527-9d8e-4013-b246-30642bf47347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e362527-9d8e-4013-b246-30642bf47347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

