### PR TITLE
chore: update cli login help description

### DIFF
--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -18,7 +18,7 @@ import { getLoggedInAccountId } from "./me.ts";
 export function registerLogin(program: Command) {
   program
     .command("login")
-    .description("Login to the San Francisco Compute Company")
+    .description("Login to SF Compute")
     .action(async () => {
       const spinner = ora("Logging in...\n").start();
 

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -18,7 +18,7 @@ import { getLoggedInAccountId } from "./me.ts";
 export function registerLogin(program: Command) {
   program
     .command("login")
-    .description("Login to the San Francisco Compute")
+    .description("Login to the San Francisco Compute Company")
     .action(async () => {
       const spinner = ora("Logging in...\n").start();
 

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -18,7 +18,7 @@ import { getLoggedInAccountId } from "./me.ts";
 export function registerLogin(program: Command) {
   program
     .command("login")
-    .description("Login to SF Compute")
+    .description("Login to the SF Compute CLI")
     .action(async () => {
       const spinner = ora("Logging in...\n").start();
 


### PR DESCRIPTION
Suggestion to tpdate login description to make it sound more natural. 

```
fnenz@MacBook-Pro build % sf
Usage: sf [options] [command]

The San Francisco Compute command line tool.

Options:
  -V, --version      output the version number
  -h, --help         display help for command

Commands:
  login              Login to the San Francisco Compute
  contracts|c        Manage contracts
```

Login to the San Francisco Compute > Login to the San Francisco Compute Company.

```
fnenz@MacBook-Pro build % sf
Usage: sf [options] [command]

The San Francisco Compute command line tool.

Options:
  -V, --version      output the version number
  -h, --help         display help for command

Commands:
  login              Login to the San Francisco Compute Company
  contracts|c        Manage contracts
```
Could also be Login to San Francisco Compute, but it looks like you often refer to the full name. 

If this short name was intentional feel free to discard this PR.