### PR TITLE
refactor: `isFeatureEnabled` uses internal feature_flag api

### DIFF
--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -81,14 +81,20 @@ export const isFeatureEnabled = async (feature: FeatureFlags) => {
     return cachedFlag.value;
   }
 
-  // If not in cache or expired, fetch from PostHog
-  const result = await postHogClient.isFeatureEnabled(
-    feature,
-    exchangeAccountId,
-  );
+  // Fetch from the v2/feature_flags API
+  let finalResult = false;
+  try {
+    const client = await apiClient(config.auth_token);
+    const { data, response } = await client.GET(
+      "/v2/feature_flags/{feature_flag_id}",
+      { params: { path: { feature_flag_id: feature } } },
+    );
+    // 404 means the flag doesn't exist → treat as disabled (false)
+    finalResult = response.ok ? (data?.enabled ?? false) : false;
+  } catch {
+    // Network or parse error → default to false
+  }
 
-  // Cache the result (PostHog returns undefined if there's an error, default to false)
-  const finalResult = result ?? false;
   await cacheFeatureFlag(feature, exchangeAccountId, finalResult);
 
   return finalResult;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1433,6 +1433,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/v2/feature_flags/{feature_flag_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get feature flag status for the authenticated user */
+    get: operations["get_feature_flag"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/v1/inference/batches": {
     parameters: {
       query?: never;
@@ -9219,6 +9236,35 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["large_scale_inference_Model"][];
+        };
+      };
+    };
+  };
+  get_feature_flag: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        feature_flag_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Feature flag status */
+      200: {
+        headers: { [name: string]: unknown };
+        content: {
+          "application/json": {
+            enabled: boolean;
+          };
+        };
+      };
+      /** @description Feature flag not found */
+      404: {
+        headers: { [name: string]: unknown };
+        content: {
+          "application/json": unknown;
         };
       };
     };


### PR DESCRIPTION
## Context

Move feature flag checks to our internal api.

## Description of Changes

We update the impl of isFeatureFlagEnabled to hit /v2/feature_flags/:flag_name to check if a feature_flag is turned on/off for a user.

Caching is left as is.
