### PR TITLE
fix: round max price to integer cents in nodes create

### DIFF
--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -267,7 +267,7 @@ async function createNodesAction(
     // Convert CLI options to SDK parameters
     const createParams: SFCNodes.NodeCreateParams = {
       desired_count: count,
-      max_price_per_node_hour: options.maxPrice * 100,
+      max_price_per_node_hour: Math.round(options.maxPrice * 100),
       names: names.length > 0 ? names : undefined,
       any_zone: options.anyZone ?? false,
       zone: options.zone,


### PR DESCRIPTION
## Summary

- Fixes a floating point precision bug in `sf nodes create` where dollar-to-cents conversion (e.g. `17.60 * 100`) could produce a non-integer value (`1760.0000000000002`), causing the API to reject the request with a deserialization error
- Adds `Math.round()` to match the handling already present in `nodes set` and `nodes extend`
