### PR TITLE
fix: validate -s/--start flag and error on unparseable values

### DIFF
--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -9,7 +9,6 @@ import utc from "dayjs/plugin/utc.js";
 import { parseDurationArgument } from "../../helpers/duration.ts";
 import { logAndQuit } from "../../helpers/errors.ts";
 import { formatNullableDateRange } from "../../helpers/format-time.ts";
-import { parseStartDateOrNow } from "../../helpers/units.ts";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -330,11 +329,25 @@ export const maxPriceOption = new Option(
 /**
  * Common --start option using same parser as buy command
  */
+function parseStartDateOrNowOrThrow(val: string): Date | "NOW" {
+  const nowRe = /\b(?:"|')?[nN][oO][wW](?:"|')?\b/;
+  if (nowRe.test(val)) return "NOW";
+  const chronoDate = parseDate(val);
+  if (!chronoDate) {
+    throw new CommanderError(
+      1,
+      "INVALID_START",
+      `Invalid start time: "${val}". Use ISO 8601 format (e.g. '2024-01-15T10:00:00Z'), a relative time (e.g. '+1h'), or 'NOW'.`,
+    );
+  }
+  return chronoDate;
+}
+
 export const startOrNowOption = new Option(
   "-s, --start <start>",
   "Start time (ISO 8601 format:'2022-10-27T14:30:00Z' or relative time like '+1d', or 'NOW')",
 )
-  .argParser(parseStartDateOrNow)
+  .argParser(parseStartDateOrNowOrThrow)
   .default("NOW" as const);
 
 /**

--- a/src/lib/nodes/utils.ts
+++ b/src/lib/nodes/utils.ts
@@ -334,9 +334,7 @@ function parseStartDateOrNowOrThrow(val: string): Date | "NOW" {
   if (nowRe.test(val)) return "NOW";
   const chronoDate = parseDate(val);
   if (!chronoDate) {
-    throw new CommanderError(
-      1,
-      "INVALID_START",
+    logAndQuit(
       `Invalid start time: "${val}". Use ISO 8601 format (e.g. '2024-01-15T10:00:00Z'), a relative time (e.g. '+1h'), or 'NOW'.`,
     );
   }


### PR DESCRIPTION
## Summary

The `-s`/`--start` flag silently accepted any string. When `chrono-node` couldn't parse the input, the argParser fell back to `"NOW"` with no error — the command would proceed as if `-s` hadn't been passed at all.

Added a strict argParser that calls `logAndQuit` with a clear message when the input can't be parsed as a date.

**Before** (bad input silently treated as NOW):
```
$ sf nodes create -n 1 -d "4h" -s "test minimal request" -p 24
ℹ Using start time: Today, 9:35am PDT
...
```

**After**:
```
$ sf nodes create -n 1 -d "4h" -s "test minimal request" -p 24
Invalid start time: "test minimal request". Use ISO 8601 format (e.g. '2024-01-15T10:00:00Z'), a relative time (e.g. '+1h'), or 'NOW'.
```

Valid inputs still work as expected:
```
$ sf nodes create -n 1 -d "1h" -s "+1h" -p 24
✔ Start time must be "NOW" or on an hour boundary. Choose a time: Today, 11am PDT
✔ Create 1 reserved node for ~$14.78/node/hr on richmond? Yes
✔ Successfully created 1 reserved node
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)