### PR TITLE
fix: `sf images list` and `sf images upload` 400 errors by passing workspace param

### DIFF
--- a/src/lib/images/list.ts
+++ b/src/lib/images/list.ts
@@ -6,6 +6,7 @@ import ora from "ora";
 import { apiClient } from "../../apiClient.ts";
 import { logAndQuit } from "../../helpers/errors.ts";
 import { formatDate } from "../../helpers/format-time.ts";
+import { getDefaultWorkspace } from "./utils.ts";
 
 const list = new Command("list")
   .alias("ls")
@@ -28,9 +29,13 @@ Examples:\n
   )
   .action(async (options) => {
     const client = await apiClient();
+    const workspace = await getDefaultWorkspace();
 
     const spinner = ora("Fetching images...").start();
-    const { data: result, response } = await client.GET("/v2/images");
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI schema is stale and doesn't include the workspace query param
+    const { data: result, response } = await (client as any).GET("/v2/images", {
+      params: { query: { workspace } },
+    });
     spinner.stop();
 
     if (!response.ok || !result) {

--- a/src/lib/images/list.ts
+++ b/src/lib/images/list.ts
@@ -32,8 +32,7 @@ Examples:\n
     const workspace = await getDefaultWorkspace();
 
     const spinner = ora("Fetching images...").start();
-    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI schema is stale and doesn't include the workspace query param
-    const { data: result, response } = await (client as any).GET("/v2/images", {
+    const { data: result, response } = await client.GET("/v2/images", {
       params: { query: { workspace } },
     });
     spinner.stop();

--- a/src/lib/images/upload.ts
+++ b/src/lib/images/upload.ts
@@ -12,6 +12,7 @@ import cliSpinners from "cli-spinners";
 import ora, { type Ora } from "ora";
 import { getAuthToken, loadConfig } from "../../helpers/config.ts";
 import { logAndQuit } from "../../helpers/errors.ts";
+import { getDefaultWorkspace } from "./utils.ts";
 
 async function readChunk(
   filePath: string,
@@ -84,11 +85,13 @@ const upload = new Command("upload")
 
       preparingSpinner = ora(`Preparing upload for ${name}...`).start();
 
+      const workspace = await getDefaultWorkspace();
+
       // Create image via v2 API
       const startResponse = await fetch(`${config.api_url}/v2/images`, {
         method: "POST",
         headers: apiHeaders,
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, workspace }),
       });
 
       if (!startResponse.ok) {

--- a/src/lib/images/utils.ts
+++ b/src/lib/images/utils.ts
@@ -1,0 +1,21 @@
+import { apiClient } from "../../apiClient.ts";
+import { loadConfig, saveConfig } from "../../helpers/config.ts";
+
+async function getAccountId(): Promise<string> {
+  const config = await loadConfig();
+  if (config.account_id) {
+    return config.account_id;
+  }
+  const client = await apiClient();
+  const { data } = await client.GET("/v0/me");
+  if (data?.id) {
+    await saveConfig({ ...config, account_id: data.id });
+    return data.id;
+  }
+  throw new Error("Could not determine account ID. Run 'sf login' first.");
+}
+
+export async function getDefaultWorkspace(): Promise<string> {
+  const accountId = await getAccountId();
+  return `sfc:workspace:${accountId}:default`;
+}

--- a/src/lib/images/utils.ts
+++ b/src/lib/images/utils.ts
@@ -1,21 +1,18 @@
 import { apiClient } from "../../apiClient.ts";
 import { loadConfig, saveConfig } from "../../helpers/config.ts";
 
-async function getAccountId(): Promise<string> {
-  const config = await loadConfig();
-  if (config.account_id) {
-    return config.account_id;
-  }
-  const client = await apiClient();
-  const { data } = await client.GET("/v0/me");
-  if (data?.id) {
-    await saveConfig({ ...config, account_id: data.id });
-    return data.id;
-  }
-  throw new Error("Could not determine account ID. Run 'sf login' first.");
-}
-
 export async function getDefaultWorkspace(): Promise<string> {
-  const accountId = await getAccountId();
+  const config = await loadConfig();
+  let accountId = config.account_id;
+  if (!accountId) {
+    const client = await apiClient();
+    const { data } = await client.GET("/v0/me");
+    if (data?.id) {
+      await saveConfig({ ...config, account_id: data.id });
+      accountId = data.id;
+    } else {
+      throw new Error("Could not determine account ID. Run 'sf login' first.");
+    }
+  }
   return `sfc:workspace:${accountId}:default`;
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2414,6 +2414,8 @@ export interface components {
     };
     vmorch_StartUploadRequest: {
       name: components["schemas"]["vmorch_Name"];
+      /** @description Workspace URN (e.g. sfc:workspace:{account_id}:default). */
+      workspace?: string;
     };
     /**
      * Format: int64
@@ -4988,6 +4990,8 @@ export interface operations {
         starting_after?: components["schemas"]["vmorch_ImagesCursor"];
         /** @description Cursor for backward pagination. */
         ending_before?: components["schemas"]["vmorch_ImagesCursor"];
+        /** @description Workspace URN (e.g. sfc:workspace:{account_id}:default). */
+        workspace?: string;
       };
       header?: never;
       path?: never;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`sf images list` returns a 400 error because the v2 API requires a `workspace` query parameter on `GET /v2/images` and a `workspace` field in the request body for `POST /v2/images`. The CLI was sending neither.

## Changes

**`src/schema.ts`**
- Added `workspace?: string` query param to the `list_images_v2` operation
- Added `workspace?: string` field to the `vmorch_StartUploadRequest` schema
- This keeps the openapi-fetch client properly typed — no `as any` casts needed

**New file: `src/lib/images/utils.ts`**
- Adds `getDefaultWorkspace()` which resolves the account ID from config (or fetches it via `GET /v0/me` and caches it) and returns the workspace URN `sfc:workspace:{account_id}:default`
- Follows the same `utils.ts` pattern used in other `src/lib/` feature directories

**`src/lib/images/list.ts`**
- Passes `workspace` as a query param to `GET /v2/images`

**`src/lib/images/upload.ts`**
- Includes `workspace` in the `POST /v2/images` request body alongside `name`

## Verification

- Typechecks clean (`tsc --noEmit`)
- All existing tests pass
- Lint clean (no new warnings/errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sfcompute.slack.com/archives/C08DE722TUK/p1775763784422009?thread_ts=1775763784.422009&cid=C08DE722TUK)

<div><a href="https://cursor.com/agents/bc-4a27f598-9457-5062-88c1-d9a3890c38f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a27f598-9457-5062-88c1-d9a3890c38f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

