### PR TITLE
feat(nodes): accept undocumented `--enable-infiniband` flag on `sf nodes create`

### DIFF
--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -135,6 +135,15 @@ const create = new Command("create")
       "ID of the VM image to boot on the nodes. View available images with `sf node images list`.",
     ),
   )
+  .addOption(
+    // Hidden experimental flag. Requires the (account, instance SKU) pair to
+    // be in the IB whitelist server-side; otherwise the request is rejected
+    // with 403. Kept undocumented while the field is in preview.
+    new Option(
+      "--enable-infiniband",
+      "Enable InfiniBand on the nodes (experimental, undocumented).",
+    ).hideHelp(),
+  )
   .addOption(yesOption)
   .addOption(jsonOption)
   .hook("preAction", (command) => {
@@ -274,6 +283,7 @@ async function createNodesAction(
       cloud_init_user_data: encodedUserData,
       image_id: options.image,
       node_type: isReserved ? "reserved" : "autoreserved",
+      ...(options.enableInfiniband ? { _preview_enable_infiniband: true } : {}),
     };
 
     if (isReserved) {


### PR DESCRIPTION
## Summary

Adds a hidden `--enable-infiniband` flag to `sf nodes create` that pipes through to `_preview_enable_infiniband: true` on the create call. The flag is fully functional but never shown in `--help` output, parent help, or generated man pages — matching the Rust [`sf-cli`'s `hide = true`](https://github.com/sfcompute/sfcompute/blob/main/sf-cli/src/main.rs) treatment of the same flag.

Stacked on #262 (depends on `@sfcompute/nodes-sdk-alpha@0.1.0-alpha.31` which introduces `_preview_enable_infiniband` on `NodeCreateParams`).

## Motivation

[SYS-691](https://linear.app/sfcompute/issue/SYS-691) wired the InfiniBand opt-in end-to-end through the API, gated server-side by an `(account, instance SKU)` whitelist row. The Rust `sf-cli` already exposes it as a hidden flag; this PR brings the TypeScript CLI to parity so internal/whitelisted callers can use `sf nodes create --enable-infiniband` without going through the lower-level Rust binary. Non-whitelisted callers get a 403 from the server — no client-side preflight needed.

The flag is kept hidden because the wire field is in the `_preview_` namespace and the convention is to not advertise preview surfaces externally (per sfcompute/sfcompute#5694).

## Description of changes

`src/lib/nodes/create.ts`:

- New `Option("--enable-infiniband")` with `.hideHelp()` so it doesn't appear in any rendered help text.
- In `createNodesAction`, conditionally spread `{ _preview_enable_infiniband: true }` into `createParams` when the option is set.

That's the entire diff (10 lines added).

## Testing

- `bun run check` — passes.
- `bun run lint` — passes (only the same 9 pre-existing warnings as `main`).
- Confirmed `Option.hideHelp()` actually hides the flag by parsing the command in isolation: `--enable-infiniband` does not appear in `helpInformation()` output.

## Review Callouts

1. **Problem:** Stdint-like internal users need IB-enabled nodes via the public CLI without having to drop down to `sf-cli` (Rust).
2. **API/CLI/Frontend impact:** New CLI flag, intentionally undocumented; no help/man page surface. Wire field is `_preview_enable_infiniband` (server-side aliased to the older `enable_infiniband` for one release per sfcompute/sfcompute#5694).
3. **Observability:** None.
4. **Unhappy paths:** Non-whitelisted accounts get 403 from server. `handleNodesError` surfaces this to the user as a CLI error.

[![Open in Indent](https://assets.indent.com/view-in-indent.svg)](https://app.indent.com/chats/1bd30b59-2231-4554-9250-8c363b3e390b) [![Slack Thread](https://assets.indent.com/slack-thread.svg)](https://sfcompute.slack.com/archives/C0AUEJNF9EE/p1778822011363609?thread_ts=1778618809.672159&cid=C0AUEJNF9EE)
Tag `@indent` to continue the conversation here.