### PR TITLE
feat: accept `--enable-infiniband` flag on `sf nodes create`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,21 @@ async function main() {
     .description("The San Francisco Compute command line tool.")
     .version(pkg.version);
 
+  // Hydrate `account_id` before registering commands so feature-flag-gated
+  // surfaces (e.g. `--enable-infiniband` on `sf nodes create`) resolve
+  // correctly on the very first CLI invocation after login, rather than only
+  // appearing after the cache has been seeded by a previous run.
+  const config = await loadConfig();
+  let exchangeAccountId = config.account_id;
+  if (!exchangeAccountId) {
+    const client = await apiClient(config.auth_token);
+    const { data } = await client.GET("/v1/account/me", {});
+    if (data?.id) {
+      exchangeAccountId = data.id;
+      await saveConfig({ ...config, account_id: data.id });
+    }
+  }
+
   // commands
   registerLogin(program);
   registerContracts(program);
@@ -83,18 +98,6 @@ async function main() {
       await ensureAnalyticsShutdown();
       process.exit(0);
     });
-
-    const config = await loadConfig();
-    let exchangeAccountId = config.account_id;
-
-    if (!exchangeAccountId) {
-      const client = await apiClient(config.auth_token);
-      const { data } = await client.GET("/v1/account/me", {});
-      if (data?.id) {
-        exchangeAccountId = data.id;
-        saveConfig({ ...config, account_id: data.id });
-      }
-    }
 
     program.exitOverride((error) => {
       let isError = true;

--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -21,6 +21,7 @@ import {
 } from "../../helpers/units.ts";
 import { handleNodesError, nodesClient } from "../../nodesClient.ts";
 import { GPUS_PER_NODE } from "../constants.ts";
+import { isFeatureEnabled } from "../posthog.ts";
 import {
   createNodesTable,
   durationOption,
@@ -68,11 +69,9 @@ function validateCount(val: string): number {
   return parsed;
 }
 
-export function createCreateCommand({
-  enableInfiniband,
-}: {
-  enableInfiniband: boolean;
-}) {
+export async function createCreateCommand() {
+  const enableInfiniband = await isFeatureEnabled("infiniband-preview");
+
   const create = new Command("create")
     .description("Create reserved or auto reserved nodes")
     .showHelpAfterError()

--- a/src/lib/nodes/create.ts
+++ b/src/lib/nodes/create.ts
@@ -68,149 +68,155 @@ function validateCount(val: string): number {
   return parsed;
 }
 
-const create = new Command("create")
-  .description("Create reserved or auto reserved nodes")
-  .showHelpAfterError()
-  .argument(
-    "[names...]",
-    "[Required: names or --count] Names of the nodes to create (must be unique across your account)",
-  )
-  .option(
-    "-n, --count <number>",
-    "[Required: names or --count] Number of nodes to create with auto-generated names",
-    validateCount,
-  )
-  .addOption(
-    new Option(
-      "-z, --zone <zone>",
-      "[Required: zone or --any-zone if --auto is provided] Zone for your nodes",
-    ).conflicts("any-zone"),
-  )
-  .addOption(
-    new Option("--any-zone", "Use any zone that meets requirements").conflicts(
-      "zone",
-    ),
-  )
-  .addOption(maxPriceOption)
-  .addOption(
-    new Option(
-      "--reserved",
-      "Create reserved nodes (default). Reserved nodes have an explicit start and end time.",
-    ).conflicts("auto"),
-  )
-  .addOption(
-    new Option(
-      "--auto",
-      "Create auto-reserved nodes. Auto-reserved nodes self-extend until they are released.",
-    ).conflicts("reserved"),
-  )
-  .addOption(startOrNowOption)
-  .addOption(endOption.conflicts("duration"))
-  .addOption(durationOption.conflicts("end"))
-  .option(
-    "-u, --user-data <script>",
-    "cloud-init user data script to run during VM boot",
-  )
-  .addOption(
-    new Option(
-      "-U, --user-data-file <file>",
-      "Path to a cloud-init user data script to run during VM boot",
+export function createCreateCommand({
+  enableInfiniband,
+}: {
+  enableInfiniband: boolean;
+}) {
+  const create = new Command("create")
+    .description("Create reserved or auto reserved nodes")
+    .showHelpAfterError()
+    .argument(
+      "[names...]",
+      "[Required: names or --count] Names of the nodes to create (must be unique across your account)",
     )
-      .conflicts("user-data")
-      .argParser((val) => {
-        try {
-          return readFileSync(val, "utf8");
-        } catch {
-          throw new CommanderError(
-            1,
-            "INVALID_USER_DATA",
-            "Failed to read user data file. Please check that the file exists and is readable.",
+    .option(
+      "-n, --count <number>",
+      "[Required: names or --count] Number of nodes to create with auto-generated names",
+      validateCount,
+    )
+    .addOption(
+      new Option(
+        "-z, --zone <zone>",
+        "[Required: zone or --any-zone if --auto is provided] Zone for your nodes",
+      ).conflicts("any-zone"),
+    )
+    .addOption(
+      new Option(
+        "--any-zone",
+        "Use any zone that meets requirements",
+      ).conflicts("zone"),
+    )
+    .addOption(maxPriceOption)
+    .addOption(
+      new Option(
+        "--reserved",
+        "Create reserved nodes (default). Reserved nodes have an explicit start and end time.",
+      ).conflicts("auto"),
+    )
+    .addOption(
+      new Option(
+        "--auto",
+        "Create auto-reserved nodes. Auto-reserved nodes self-extend until they are released.",
+      ).conflicts("reserved"),
+    )
+    .addOption(startOrNowOption)
+    .addOption(endOption.conflicts("duration"))
+    .addOption(durationOption.conflicts("end"))
+    .option(
+      "-u, --user-data <script>",
+      "cloud-init user data script to run during VM boot",
+    )
+    .addOption(
+      new Option(
+        "-U, --user-data-file <file>",
+        "Path to a cloud-init user data script to run during VM boot",
+      )
+        .conflicts("user-data")
+        .argParser((val) => {
+          try {
+            return readFileSync(val, "utf8");
+          } catch {
+            throw new CommanderError(
+              1,
+              "INVALID_USER_DATA",
+              "Failed to read user data file. Please check that the file exists and is readable.",
+            );
+          }
+        }),
+    )
+    .addOption(
+      new Option(
+        "-i, --image <image-id>",
+        "ID of the VM image to boot on the nodes. View available images with `sf node images list`.",
+      ),
+    )
+    .addOption(yesOption)
+    .addOption(jsonOption)
+    .hook("preAction", (command) => {
+      const names = command.args;
+      const { count, start, duration, end, auto, reserved, anyZone, zone } =
+        command.opts();
+
+      // Validate arguments
+      if (names.length === 0 && !count) {
+        command.error(
+          chalk.red("Must specify either node names or use `--count` option\n"),
+        );
+      }
+
+      if (names.length > 0 && count) {
+        if (names.length !== count) {
+          command.error(
+            chalk.red(
+              `You specified ${names.length} ${
+                names.length === 1 ? "node name" : "node names"
+              } but \`--count\` is set to ${count}. The number of names must match the \`count\`.\n`,
+            ),
           );
         }
-      }),
-  )
-  .addOption(
-    new Option(
-      "-i, --image <image-id>",
-      "ID of the VM image to boot on the nodes. View available images with `sf node images list`.",
-    ),
-  )
-  .addOption(yesOption)
-  .addOption(jsonOption)
-  .hook("preAction", (command) => {
-    const names = command.args;
-    const { count, start, duration, end, auto, reserved, anyZone, zone } =
-      command.opts();
+      }
 
-    // Validate arguments
-    if (names.length === 0 && !count) {
-      command.error(
-        chalk.red("Must specify either node names or use `--count` option\n"),
-      );
-    }
-
-    if (names.length > 0 && count) {
-      if (names.length !== count) {
+      if (auto && !anyZone && !zone) {
         command.error(
           chalk.red(
-            `You specified ${names.length} ${
-              names.length === 1 ? "node name" : "node names"
-            } but \`--count\` is set to ${count}. The number of names must match the \`count\`.\n`,
+            "If --auto is provided, you must specify a zone or use --any-zone\n",
           ),
         );
       }
-    }
 
-    if (auto && !anyZone && !zone) {
-      command.error(
-        chalk.red(
-          "If --auto is provided, you must specify a zone or use --any-zone\n",
-        ),
-      );
-    }
+      if (reserved && auto) {
+        command.error(
+          chalk.red("Specify either --reserved or --auto, but not both\n"),
+        );
+      }
 
-    if (reserved && auto) {
-      command.error(
-        chalk.red("Specify either --reserved or --auto, but not both\n"),
-      );
-    }
+      // Validate duration/end like buy command
+      if (typeof end !== "undefined" && typeof duration !== "undefined") {
+        command.error(
+          chalk.red("Specify either --duration or --end, but not both\n"),
+        );
+      }
 
-    // Validate duration/end like buy command
-    if (typeof end !== "undefined" && typeof duration !== "undefined") {
-      command.error(
-        chalk.red("Specify either --duration or --end, but not both\n"),
-      );
-    }
+      // Validate that timing flags are only used with reserved nodes
+      if (
+        auto &&
+        (start !== "NOW" ||
+          typeof duration !== "undefined" ||
+          typeof end !== "undefined")
+      ) {
+        command.error(
+          chalk.red(
+            "Auto-reserved nodes start immediately and cannot have a start time, duration, or end time.\n",
+          ),
+        );
+      }
 
-    // Validate that timing flags are only used with reserved nodes
-    if (
-      auto &&
-      (start !== "NOW" ||
-        typeof duration !== "undefined" ||
-        typeof end !== "undefined")
-    ) {
-      command.error(
-        chalk.red(
-          "Auto-reserved nodes start immediately and cannot have a start time, duration, or end time.\n",
-        ),
-      );
-    }
-
-    if (
-      !auto &&
-      typeof duration === "undefined" &&
-      typeof end === "undefined"
-    ) {
-      command.error(
-        chalk.red(
-          "You must specify either --duration or --end to create a reserved node.\n",
-        ),
-      );
-    }
-  })
-  .addHelpText(
-    "after",
-    `
+      if (
+        !auto &&
+        typeof duration === "undefined" &&
+        typeof end === "undefined"
+      ) {
+        command.error(
+          chalk.red(
+            "You must specify either --duration or --end to create a reserved node.\n",
+          ),
+        );
+      }
+    })
+    .addHelpText(
+      "after",
+      `
 Notes:
   - Either provide node names as arguments OR use --count (one is required)
   - For reserved nodes (default): either --duration or --end is required
@@ -235,266 +241,286 @@ Examples:\n
   \x1b[2m# Create a reserved node starting in 1 hour for 6 hours\x1b[0m
   $ sf nodes create node-1 --zone hayesvalley --reserved --start "+1h" --duration 6h -p 11.25
 `,
-  )
-  .action(createNodesAction);
+    )
+    .action(createNodesAction);
 
-async function createNodesAction(
-  names: typeof create.args,
-  options: ReturnType<typeof create.opts> & { image?: string },
-) {
-  try {
-    const client = await nodesClient();
-    const count = options.count ?? names.length;
-    // Because we validate that --reserved and --auto are mutually exclusive,
-    // we can use the presence of --auto to determine if the nodes are auto-reserved.
-    const isReserved = !options.auto;
-    const nodeType = options.auto
-      ? ("autoreserved" as const)
-      : ("reserved" as const);
+  if (enableInfiniband) {
+    create.addOption(
+      new Option(
+        "--enable-infiniband",
+        "Enable InfiniBand passthrough on the node VMs.",
+      ),
+    );
+  }
 
-    const rawUserData = options.userData ?? options.userDataFile;
-    const wellFormedUserData = rawUserData?.isWellFormed?.()
-      ? rawUserData
-      : rawUserData
-        ? encodeURIComponent(rawUserData)
+  return create;
+
+  async function createNodesAction(
+    names: typeof create.args,
+    options: ReturnType<typeof create.opts> & {
+      image?: string;
+      enableInfiniband?: boolean;
+    },
+  ) {
+    try {
+      const client = await nodesClient();
+      const count = options.count ?? names.length;
+      // Because we validate that --reserved and --auto are mutually exclusive,
+      // we can use the presence of --auto to determine if the nodes are auto-reserved.
+      const isReserved = !options.auto;
+      const nodeType = options.auto
+        ? ("autoreserved" as const)
+        : ("reserved" as const);
+
+      const rawUserData = options.userData ?? options.userDataFile;
+      const wellFormedUserData = rawUserData?.isWellFormed?.()
+        ? rawUserData
+        : rawUserData
+          ? encodeURIComponent(rawUserData)
+          : undefined;
+      const encodedUserData = wellFormedUserData
+        ? btoa(
+            String.fromCodePoint(
+              ...new TextEncoder().encode(wellFormedUserData),
+            ),
+          )
         : undefined;
-    const encodedUserData = wellFormedUserData
-      ? btoa(
-          String.fromCodePoint(...new TextEncoder().encode(wellFormedUserData)),
-        )
-      : undefined;
 
-    // Convert CLI options to SDK parameters
-    const createParams: SFCNodes.NodeCreateParams = {
-      desired_count: count,
-      max_price_per_node_hour: Math.round(options.maxPrice * 100),
-      names: names.length > 0 ? names : undefined,
-      any_zone: options.anyZone ?? false,
-      zone: options.zone,
-      cloud_init_user_data: encodedUserData,
-      image_id: options.image,
-      node_type: isReserved ? "reserved" : "autoreserved",
-    };
+      // Convert CLI options to SDK parameters
+      const createParams: SFCNodes.NodeCreateParams = {
+        desired_count: count,
+        max_price_per_node_hour: Math.round(options.maxPrice * 100),
+        names: names.length > 0 ? names : undefined,
+        any_zone: options.anyZone ?? false,
+        zone: options.zone,
+        cloud_init_user_data: encodedUserData,
+        image_id: options.image,
+        node_type: isReserved ? "reserved" : "autoreserved",
+        ...(options.enableInfiniband
+          ? { _preview_enable_infiniband: true }
+          : {}),
+      };
 
-    if (isReserved) {
-      // Handle start time (options.start comes from parseStartDateOrNow parser)
-      const startDate = options.start;
+      if (isReserved) {
+        // Handle start time (options.start comes from parseStartDateOrNow parser)
+        const startDate = options.start;
 
-      // Check if the start date is "NOW" or on an hour boundary
-      const startDateIsValid =
-        startDate === "NOW" ||
-        dayjs(startDate).startOf("hour").isSame(dayjs(startDate));
+        // Check if the start date is "NOW" or on an hour boundary
+        const startDateIsValid =
+          startDate === "NOW" ||
+          dayjs(startDate).startOf("hour").isSame(dayjs(startDate));
 
-      if (!startDateIsValid) {
-        if (!options.yes) {
-          options.start = await selectTime(startDate, {
-            message: `Start time must be "NOW" or on an hour boundary. ${chalk.cyan(
-              "Choose a time:",
-            )}`,
-          });
-        } else {
-          // Clamp down to "NOW" or lower hour
-          const suggestedLowerStart = dayjs(startDate).startOf("hour");
-          options.start =
-            suggestedLowerStart < dayjs()
-              ? "NOW"
-              : suggestedLowerStart.toDate();
-        }
-      }
-      // Pass undefined for "NOW" to avoid race conditions - the API will use current time
-      if (options.start !== "NOW") {
-        createParams.start_at = Math.floor(options.start.getTime() / 1000);
-      }
-
-      // Handle end time and/or duration
-      if (options.end || options.duration) {
-        let endDate = options.end;
-        const endStartTime =
-          typeof options.start === "string" ? new Date() : options.start;
-        if (!endDate) {
-          // Use the actual start time (current time if "NOW", or the specified start)
-          endDate = new Date(endStartTime.getTime() + options.duration! * 1000);
-        }
-
-        const endDateIsValid = dayjs(endDate).isSame(
-          dayjs(endDate).startOf("hour"),
-        );
-        if (!endDateIsValid) {
-          // If the start time was valid, show the user the start time so they're no confused about
-          // which time they're selecting
-          if (startDateIsValid) {
-            ora(
-              `Using start time: ${chalk.cyan(
-                `${formatDate(endStartTime, { forceIncludeTime: true })} ${dayjs(
-                  endStartTime,
-                ).format("z")}`,
-              )}`,
-            ).info();
-          }
+        if (!startDateIsValid) {
           if (!options.yes) {
-            const selectedTime = await selectTime(endDate, {
-              message: `End time must be on an hour boundary. ${chalk.cyan(
+            options.start = await selectTime(startDate, {
+              message: `Start time must be "NOW" or on an hour boundary. ${chalk.cyan(
                 "Choose a time:",
               )}`,
             });
-            endDate = selectedTime === "NOW" ? new Date() : selectedTime;
           } else {
-            const suggestedHigherEnd = dayjs(endDate)
-              .startOf("hour")
-              .add(1, "hour");
-            endDate =
-              suggestedHigherEnd < dayjs()
-                ? new Date()
-                : suggestedHigherEnd.toDate();
+            // Clamp down to "NOW" or lower hour
+            const suggestedLowerStart = dayjs(startDate).startOf("hour");
+            options.start =
+              suggestedLowerStart < dayjs()
+                ? "NOW"
+                : suggestedLowerStart.toDate();
           }
         }
-        createParams.end_at = Math.floor(endDate.getTime() / 1000);
-      }
-    }
-
-    // Only show pricing and get confirmation if not using --yes
-    if (!options.yes) {
-      let confirmationMessage = `Create ${formatNodeDescription(
-        count,
-        nodeType,
-      )}`;
-
-      if (isReserved) {
-        // Reserved nodes - get quote for accurate pricing
-        const spinner = ora(
-          `Quoting ${formatNodeDescription(count, nodeType)}...`,
-        ).start();
-
-        // Calculate duration for quote
-        let durationSeconds = 3600; // Default 1 hour
-        if (options.duration) {
-          durationSeconds = options.duration;
-        } else if (options.end) {
-          const startDate =
-            typeof options.start === "string" ? new Date() : options.start;
-          durationSeconds = Math.floor(
-            (options.end.getTime() - startDate.getTime()) / 1000,
-          );
+        // Pass undefined for "NOW" to avoid race conditions - the API will use current time
+        if (options.start !== "NOW") {
+          createParams.start_at = Math.floor(options.start.getTime() / 1000);
         }
 
-        // Add flexibility to duration for better quote matching (matches buy command logic)
-        const startsAt =
-          options.start === "NOW"
-            ? "NOW"
-            : roundStartDate(parseStartDate(options.start));
-        const minDurationSeconds = Math.max(
-          1,
-          durationSeconds - Math.ceil(durationSeconds * 0.1),
-        );
-        const maxDurationSeconds = Math.max(
-          durationSeconds + 3600,
-          durationSeconds + Math.ceil(durationSeconds * 0.1),
-        );
+        // Handle end time and/or duration
+        if (options.end || options.duration) {
+          let endDate = options.end;
+          const endStartTime =
+            typeof options.start === "string" ? new Date() : options.start;
+          if (!endDate) {
+            // Use the actual start time (current time if "NOW", or the specified start)
+            endDate = new Date(
+              endStartTime.getTime() + options.duration! * 1000,
+            );
+          }
 
-        // Use default instance type h100i and zone if provided
-        const quote = await getQuote({
-          instanceType: "h100v", // This should get ignored by the zone
-          quantity: count,
-          minStartTime: startsAt,
-          maxStartTime: startsAt,
-          minDurationSeconds: minDurationSeconds,
-          maxDurationSeconds: maxDurationSeconds,
-          cluster: options.zone,
-        });
+          const endDateIsValid = dayjs(endDate).isSame(
+            dayjs(endDate).startOf("hour"),
+          );
+          if (!endDateIsValid) {
+            // If the start time was valid, show the user the start time so they're no confused about
+            // which time they're selecting
+            if (startDateIsValid) {
+              ora(
+                `Using start time: ${chalk.cyan(
+                  `${formatDate(endStartTime, { forceIncludeTime: true })} ${dayjs(
+                    endStartTime,
+                  ).format("z")}`,
+                )}`,
+              ).info();
+            }
+            if (!options.yes) {
+              const selectedTime = await selectTime(endDate, {
+                message: `End time must be on an hour boundary. ${chalk.cyan(
+                  "Choose a time:",
+                )}`,
+              });
+              endDate = selectedTime === "NOW" ? new Date() : selectedTime;
+            } else {
+              const suggestedHigherEnd = dayjs(endDate)
+                .startOf("hour")
+                .add(1, "hour");
+              endDate =
+                suggestedHigherEnd < dayjs()
+                  ? new Date()
+                  : suggestedHigherEnd.toDate();
+            }
+          }
+          createParams.end_at = Math.floor(endDate.getTime() / 1000);
+        }
+      }
 
-        spinner.stop();
+      // Only show pricing and get confirmation if not using --yes
+      if (!options.yes) {
+        let confirmationMessage = `Create ${formatNodeDescription(
+          count,
+          nodeType,
+        )}`;
 
-        if (quote) {
-          const pricePerGpuHour = getPricePerGpuHourFromQuote(quote);
-          const pricePerNodeHour = (pricePerGpuHour * GPUS_PER_NODE) / 100;
-          confirmationMessage += ` for ~$${pricePerNodeHour.toFixed(
+        if (isReserved) {
+          // Reserved nodes - get quote for accurate pricing
+          const spinner = ora(
+            `Quoting ${formatNodeDescription(count, nodeType)}...`,
+          ).start();
+
+          // Calculate duration for quote
+          let durationSeconds = 3600; // Default 1 hour
+          if (options.duration) {
+            durationSeconds = options.duration;
+          } else if (options.end) {
+            const startDate =
+              typeof options.start === "string" ? new Date() : options.start;
+            durationSeconds = Math.floor(
+              (options.end.getTime() - startDate.getTime()) / 1000,
+            );
+          }
+
+          // Add flexibility to duration for better quote matching (matches buy command logic)
+          const startsAt =
+            options.start === "NOW"
+              ? "NOW"
+              : roundStartDate(parseStartDate(options.start));
+          const minDurationSeconds = Math.max(
+            1,
+            durationSeconds - Math.ceil(durationSeconds * 0.1),
+          );
+          const maxDurationSeconds = Math.max(
+            durationSeconds + 3600,
+            durationSeconds + Math.ceil(durationSeconds * 0.1),
+          );
+
+          // Use default instance type h100i and zone if provided
+          const quote = await getQuote({
+            instanceType: "h100v", // This should get ignored by the zone
+            quantity: count,
+            minStartTime: startsAt,
+            maxStartTime: startsAt,
+            minDurationSeconds: minDurationSeconds,
+            maxDurationSeconds: maxDurationSeconds,
+            cluster: options.zone,
+          });
+
+          spinner.stop();
+
+          if (quote) {
+            const pricePerGpuHour = getPricePerGpuHourFromQuote(quote);
+            const pricePerNodeHour = (pricePerGpuHour * GPUS_PER_NODE) / 100;
+            confirmationMessage += ` for ~$${pricePerNodeHour.toFixed(
+              2,
+            )}/node/hr`;
+            if ("zone" in quote) {
+              confirmationMessage += ` on ${chalk.cyan(quote.zone)}`;
+              createParams.zone ||= quote.zone;
+            }
+          } else {
+            logAndQuit(
+              chalk.red(
+                "No capacity available matching your hardware and pricing requirements. You can view zone capacity at https://sfcompute.com/dashboard/zones.",
+              ),
+            );
+          }
+        } else if (options.maxPrice) {
+          // Auto Reserved nodes - show max price they're willing to pay
+          confirmationMessage += ` for up to $${options.maxPrice.toFixed(
             2,
           )}/node/hr`;
-          if ("zone" in quote) {
-            confirmationMessage += ` on ${chalk.cyan(quote.zone)}`;
-            createParams.zone ||= quote.zone;
+          if (options.zone) {
+            confirmationMessage += ` on ${chalk.cyan(options.zone)}`;
+          } else {
+            confirmationMessage += " on any matching zone";
           }
-        } else {
-          logAndQuit(
-            chalk.red(
-              "No capacity available matching your hardware and pricing requirements. You can view zone capacity at https://sfcompute.com/dashboard/zones.",
-            ),
-          );
         }
-      } else if (options.maxPrice) {
-        // Auto Reserved nodes - show max price they're willing to pay
-        confirmationMessage += ` for up to $${options.maxPrice.toFixed(
-          2,
-        )}/node/hr`;
-        if (options.zone) {
-          confirmationMessage += ` on ${chalk.cyan(options.zone)}`;
-        } else {
-          confirmationMessage += " on any matching zone";
+
+        // Add node names at the end after a colon
+        if (names.length > 0) {
+          confirmationMessage += `: ${names.join(", ")}`;
         }
+
+        const confirmed = await confirm({
+          message: confirmationMessage + "?",
+          default: false,
+        });
+        if (!confirmed) process.exit(0);
       }
 
-      // Add node names at the end after a colon
-      if (names.length > 0) {
-        confirmationMessage += `: ${names.join(", ")}`;
-      }
+      const spinner = ora(
+        `Creating ${formatNodeDescription(count, nodeType)}...`,
+      ).start();
 
-      const confirmed = await confirm({
-        message: confirmationMessage + "?",
-        default: false,
-      });
-      if (!confirmed) process.exit(0);
-    }
+      try {
+        const { data: createdNodes } = await client.nodes.create(createParams);
 
-    const spinner = ora(
-      `Creating ${formatNodeDescription(count, nodeType)}...`,
-    ).start();
-
-    try {
-      const { data: createdNodes } = await client.nodes.create(createParams);
-
-      spinner.succeed(
-        `Successfully created ${formatNodeDescription(
-          createdNodes.length,
-          nodeType,
-        )}`,
-      );
-
-      if (options.json) {
-        console.log(JSON.stringify(createdNodes, null, 2));
-        process.exit(0);
-      }
-
-      if (createdNodes.length > 0) {
-        console.log(chalk.gray("\nCreated nodes:"));
-        console.log(createNodesTable(createdNodes));
-        console.log(`\n${chalk.gray("Next steps:")}`);
-        console.log("  sf nodes list");
-        // Auto Reserved nodes can't be extended, so only suggest it for reserved nodes
-        if (isReserved) {
-          console.log(
-            `  sf nodes extend ${chalk.cyan(createdNodes?.[0]?.name ?? "my-node")}`,
-          );
-        } else {
-          console.log(
-            `  sf nodes set ${chalk.cyan(
-              createdNodes?.[0]?.name ?? "my-node",
-            )} --max-price ${chalk.cyan("12.50")}`,
-          );
-        }
-        console.log(
-          `  sf nodes release ${chalk.cyan(createdNodes?.[0]?.name ?? "my-node")}`,
+        spinner.succeed(
+          `Successfully created ${formatNodeDescription(
+            createdNodes.length,
+            nodeType,
+          )}`,
         );
-      } else {
-        console.log(chalk.yellow("No nodes created.\n"));
-        create.help();
+
+        if (options.json) {
+          console.log(JSON.stringify(createdNodes, null, 2));
+          process.exit(0);
+        }
+
+        if (createdNodes.length > 0) {
+          console.log(chalk.gray("\nCreated nodes:"));
+          console.log(createNodesTable(createdNodes));
+          console.log(`\n${chalk.gray("Next steps:")}`);
+          console.log("  sf nodes list");
+          // Auto Reserved nodes can't be extended, so only suggest it for reserved nodes
+          if (isReserved) {
+            console.log(
+              `  sf nodes extend ${chalk.cyan(createdNodes?.[0]?.name ?? "my-node")}`,
+            );
+          } else {
+            console.log(
+              `  sf nodes set ${chalk.cyan(
+                createdNodes?.[0]?.name ?? "my-node",
+              )} --max-price ${chalk.cyan("12.50")}`,
+            );
+          }
+          console.log(
+            `  sf nodes release ${chalk.cyan(createdNodes?.[0]?.name ?? "my-node")}`,
+          );
+        } else {
+          console.log(chalk.yellow("No nodes created.\n"));
+          create.help();
+        }
+      } catch (err) {
+        spinner.fail("Failed to create nodes");
+        throw err;
       }
     } catch (err) {
-      spinner.fail("Failed to create nodes");
-      throw err;
+      handleNodesError(err);
     }
-  } catch (err) {
-    handleNodesError(err);
   }
 }
-
-export default create;

--- a/src/lib/nodes/index.ts
+++ b/src/lib/nodes/index.ts
@@ -1,7 +1,6 @@
 import console from "node:console";
 import type { Command } from "@commander-js/extra-typings";
 import { createImagesCommand } from "../images/index.ts";
-import { isFeatureEnabled } from "../posthog.ts";
 import { createCreateCommand } from "./create.ts";
 import deleteCommand from "./delete.ts";
 import extend from "./extend.ts";
@@ -14,8 +13,6 @@ import set from "./set.ts";
 import ssh from "./ssh.ts";
 
 export async function registerNodes(program: Command) {
-  const enableInfiniband = await isFeatureEnabled("infiniband-preview");
-
   const nodes = program
     .command("nodes")
     .alias("node")
@@ -23,7 +20,7 @@ export async function registerNodes(program: Command) {
     .description("Manage compute nodes")
     .addCommand(list)
     .addCommand(get)
-    .addCommand(createCreateCommand({ enableInfiniband }))
+    .addCommand(await createCreateCommand())
     .addCommand(extend)
     .addCommand(release)
     .addCommand(deleteCommand)

--- a/src/lib/nodes/index.ts
+++ b/src/lib/nodes/index.ts
@@ -1,7 +1,8 @@
 import console from "node:console";
 import type { Command } from "@commander-js/extra-typings";
 import { createImagesCommand } from "../images/index.ts";
-import create from "./create.ts";
+import { isFeatureEnabled } from "../posthog.ts";
+import { createCreateCommand } from "./create.ts";
 import deleteCommand from "./delete.ts";
 import extend from "./extend.ts";
 import get from "./get.tsx";
@@ -12,7 +13,9 @@ import release from "./release.ts";
 import set from "./set.ts";
 import ssh from "./ssh.ts";
 
-export function registerNodes(program: Command) {
+export async function registerNodes(program: Command) {
+  const enableInfiniband = await isFeatureEnabled("infiniband-preview");
+
   const nodes = program
     .command("nodes")
     .alias("node")
@@ -20,7 +23,7 @@ export function registerNodes(program: Command) {
     .description("Manage compute nodes")
     .addCommand(list)
     .addCommand(get)
-    .addCommand(create)
+    .addCommand(createCreateCommand({ enableInfiniband }))
     .addCommand(extend)
     .addCommand(release)
     .addCommand(deleteCommand)

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -62,7 +62,7 @@ const trackEvent = ({
   }
 };
 
-type FeatureFlags = "procurements" | "zones";
+type FeatureFlags = "procurements" | "zones" | "infiniband-preview";
 
 /**
  * Checks if a feature is enabled for the current user.


### PR DESCRIPTION
> Reopen of #263 — that PR's branch was force-recreated during a restack, so GitHub wouldn't let it be reopened. Identical intent, rebased onto the restacked #262.

## Summary

Adds an `--enable-infiniband` flag to `sf nodes create` that forwards `_preview_enable_infiniband: true` on the create call. The flag is gated behind the `infiniband-preview` PostHog feature flag and is only mounted when that flag is enabled for the caller's account — accounts without it see no surface change. Flagged accounts **do** see the option in `sf nodes create --help`; preview/experimental expectations are set out-of-band ("white glove") for those customers. Server-side allowlisting (per `(account, instance SKU)`) does the real enforcement, so non-allowlisted callers still get a 403.

Stacked on #262 (depends on `@sfcompute/nodes-sdk-alpha@0.1.0-alpha.31` which exposes `_preview_enable_infiniband` on `NodeCreateParams`).

## Description of changes

- `src/lib/posthog.ts`: extend `FeatureFlags` with `"infiniband-preview"`.
- `src/lib/nodes/create.ts`: `createCreateCommand` now takes `{ enableInfiniband }`; when true, the option is added to the command and `_preview_enable_infiniband: true` is spread into the SDK params.
- `src/lib/nodes/index.ts`: resolves the feature flag and threads it into the factory.
- `src/index.ts`: hoist `account_id` hydration above the `register*` calls so feature-flag-gated surfaces resolve on the very first CLI invocation after login (previously they only appeared on the second run, once the cache was seeded).

## Testing

- `bun run lint` — passes (same pre-existing warnings as `main`).
- Confirmed the option only appears in `sf nodes create --help` when the feature flag resolves true.
- Confirmed the option appears on the first invocation after a fresh login (post-hoist).
