### PR TITLE
fix: accept `api_token` as an alias for `token` in `sf login`

### DIFF
--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -97,9 +97,17 @@ async function getSession({ token }: { token: string }) {
       },
     });
 
-    return response.data as {
+    // The auth JWT is returned as `token` today; accept `api_token` as a
+    // fallback so the CLI is forward-compatible with a server-side rename.
+    const data = response.data as {
       validation?: string;
       token?: string;
+      api_token?: string;
+    };
+
+    return {
+      validation: data.validation,
+      token: data.token ?? data.api_token,
     };
   } catch (error) {
     console.error("Error getting session:", error);


### PR DESCRIPTION
## Summary
- Accept either `token` or `api_token` in the `getSession` polling response so the CLI is forward- and backward-compatible across the cutover.

## Motivation
 **Field rename** — the polling response uses `api_token` on console where the old site used `token`. The newer rust CLI already tolerates both; this PR brings the standalone `sf` cli in line so it keeps working both before and after the DNS flip to `sfcompute.com -> console.sfcompute.com`.

## Testing

- `bun run check` — clean.
- `bunx biome ci .` — clean (only pre-existing warnings).
- `bun run test` — 9 / 9 pass.
- Manual `sf login` end-to-end against console pending from a human; @Gii2000 already verified the JWT flow on both sites.