### PR TITLE
fix: [PR-1797] suppress migration banner after `sf migrate` completes

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -11,6 +11,7 @@ export interface Config {
   webapp_url: string;
   auth_token?: string;
   account_id?: string;
+  migrated_to_rust_cli?: boolean;
 }
 
 const ProductionConfigDefaults = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ async function main() {
     process.env.SF_CLI_DISABLE_AUTO_UPGRADE = "1";
   }
 
+  // Load config early so the migration banner can honor the persisted
+  // `migrated_to_rust_cli` flag written by a successful `sf migrate`.
+  const config = await loadConfig();
+
   if (!process.argv.includes("--json")) {
     const [shownUpgradeBanner] = await Promise.all([
       checkVersion(),
@@ -51,14 +55,16 @@ async function main() {
     // them toward the new Rust CLI instead of showing nothing. We avoid
     // double-stacking with the upgrade banner since users on outdated builds
     // need to upgrade before migrating, and skip the banner for the
-    // `upgrade` / `migrate` commands themselves (where it'd just be noise)
-    // and for users who've opted out via SF_CLI_DISABLE_MIGRATE_BANNER.
+    // `upgrade` / `migrate` commands themselves (where it'd just be noise),
+    // for users who've opted out via SF_CLI_DISABLE_MIGRATE_BANNER, and for
+    // users who've already migrated (the flag is set by `sf migrate`).
     const subcommand = process.argv[2];
     if (
       !shownUpgradeBanner &&
       subcommand !== "migrate" &&
       subcommand !== "upgrade" &&
-      !process.env.SF_CLI_DISABLE_MIGRATE_BANNER
+      !process.env.SF_CLI_DISABLE_MIGRATE_BANNER &&
+      !config.migrated_to_rust_cli
     ) {
       showMigrateBanner();
     }
@@ -73,7 +79,6 @@ async function main() {
   // surfaces (e.g. `--enable-infiniband` on `sf nodes create`) resolve
   // correctly on the very first CLI invocation after login, rather than only
   // appearing after the cache has been seeded by a previous run.
-  const config = await loadConfig();
   let exchangeAccountId = config.account_id;
   if (!exchangeAccountId) {
     const client = await apiClient(config.auth_token);

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -5,6 +5,7 @@ import type { Command } from "@commander-js/extra-typings";
 import boxen from "boxen";
 import chalk from "chalk";
 import ora from "ora";
+import { loadConfig, saveConfig } from "../helpers/config.ts";
 
 const NEW_CLI_INSTALL_URL = "https://cli.sfcompute.com";
 const MIGRATION_GUIDE_URL = "https://sfcompute.com/migrate";
@@ -97,6 +98,15 @@ export function registerMigrate(program: Command) {
           console.error(chalk.red("\nMigration failed."));
           process.exit(1);
         }
+      }
+
+      // Persist a flag so future `sf-old` invocations don't nag the user with
+      // the migration banner.
+      try {
+        const config = await loadConfig();
+        await saveConfig({ ...config, migrated_to_rust_cli: true });
+      } catch {
+        // Best-effort: a failure here just means the banner keeps showing.
       }
 
       console.log(


### PR DESCRIPTION
## Summary
- Persist `migrated_to_rust_cli: true` in `~/.sfcompute/config` when `sf migrate` succeeds.
- Gate the migration banner on that flag so `sf-old` stops nagging users who've already migrated.
- `SF_CLI_DISABLE_MIGRATE_BANNER` continues to work as an explicit override.

## Test plan
- [ ] Run `sf migrate` on a clean config; verify `migrated_to_rust_cli: true` is written.
- [ ] Re-run `sf-old <anything>` and confirm the migration banner no longer renders.
- [ ] With the flag absent, banner still appears as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)