### PR TITLE
chore: [CLD-2844] deprecate sfcompute/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 > **This repository is deprecated and no longer maintained.**
 >
 > The San Francisco Compute `sf` CLI has been rewritten in Rust. If you have
-> this legacy CLI installed, run `sf migrate` to switch — your current CLI will
-> remain available as `sf-old`.
+> this legacy CLI installed, run `sf migrate` to switch.
 >
 > - Install the current CLI: <https://cli.sfcompute.com>
 > - Migration guide: <https://sfcompute.com/migrate>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # cli
 
+> [!WARNING]
+> **This repository is deprecated and no longer maintained.**
+>
+> The San Francisco Compute `sf` CLI has been rewritten in Rust. If you have
+> this legacy CLI installed, run `sf migrate` to switch — your current CLI will
+> remain available as `sf-old`.
+>
+> - Install the current CLI: <https://cli.sfcompute.com>
+> - Migration guide: <https://sfcompute.com/migrate>
+>
+> The documentation below is retained for archival reference only.
+
 This is the San Francisco Compute command line tool.
 
 ### Install (MacOS/Linux)

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -11,22 +11,22 @@ const NEW_CLI_INSTALL_URL = "https://cli.sfcompute.com";
 const MIGRATION_GUIDE_URL = "https://sfcompute.com/migrate";
 
 export function showMigrateBanner() {
-  const message = `We've rewritten the sf CLI in Rust.
+  const message = `This CLI is deprecated and no longer maintained.
 
-List idle capacity on the orderbook to
-recoup up to 20% of your spend.
-
-Run 'sf migrate' to switch. Your current
-CLI stays as 'sf-old'.
+The sf CLI has been rewritten in Rust. Run
+'sf migrate' to switch. Your current CLI
+stays available as 'sf-old'.
 
 Docs:  ${MIGRATION_GUIDE_URL}
 Hide:  SF_CLI_DISABLE_MIGRATE_BANNER=1`;
 
   console.log(
-    boxen(chalk.yellow(message), {
+    boxen(chalk.red(message), {
       padding: 1,
-      borderColor: "yellow",
+      borderColor: "red",
       borderStyle: "round",
+      title: "Deprecated",
+      titleAlignment: "center",
     }),
   );
 }

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -14,8 +14,7 @@ export function showMigrateBanner() {
   const message = `This CLI is deprecated and no longer maintained.
 
 The sf CLI has been rewritten in Rust. Run
-'sf migrate' to switch. Your current CLI
-stays available as 'sf-old'.
+'sf migrate' to switch.
 
 Docs:  ${MIGRATION_GUIDE_URL}
 Hide:  SF_CLI_DISABLE_MIGRATE_BANNER=1`;


### PR DESCRIPTION
## What

Deprecate the legacy TypeScript `sf` CLI ahead of archiving this repo.

Part of the [CLD-2844](https://linear.app/sfcompute/issue/CLD-2844/deprecate-sfcomputecli) plan (from [this Slack thread](https://sfcompute.slack.com/archives/C07H4NN1HH8/p1784149874518889)):

- [x] Update README
- [x] Add a deprecation warning to the CLI on startup
- [ ] Release new release
- [ ] Archive the repo *(done manually after this merges — archiving makes the repo read-only, so it has to come last)*

## Changes

- **`src/lib/migrate.ts`** — the startup migrate banner is now a red **"Deprecated"** notice: *"This CLI is deprecated and no longer maintained."* It keeps the `sf migrate` call-to-action, the docs link, and the `SF_CLI_DISABLE_MIGRATE_BANNER` opt-out. No change to when it shows (still skipped for `--json`, `migrate`/`upgrade`, opted-out, and already-migrated users).
- **`README.md`** — leads with a `> [!WARNING]` deprecation block pointing at the Rust CLI (install + migration guide). Existing docs kept below for archival reference.

## Banner preview

```
╭───────────────────── Deprecated ─────────────────────╮
│                                                      │
│   This CLI is deprecated and no longer maintained.   │
│                                                      │
│   The sf CLI has been rewritten in Rust. Run         │
│   'sf migrate' to switch. Your current CLI           │
│   stays available as 'sf-old'.                       │
│                                                      │
│   Docs:  https://sfcompute.com/migrate               │
│   Hide:  SF_CLI_DISABLE_MIGRATE_BANNER=1             │
│                                                      │
╰──────────────────────────────────────────────────────╯
```

## Verification

- `tsc --noEmit` passes clean.
- `biome check` reports only pre-existing warnings in untouched `src/lib/scale/` files.

## Notes

- The banner change only reaches installed users once a new version is published — flag if we want a release cut, otherwise landing the code + archiving is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
